### PR TITLE
Chore/single public library

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,6 @@ Then run `dart pub get` or `flutter pub get` and import the library:
 
 ```dart
 import 'package:option_result/option_result.dart';
-// or import the separate types individually:
-import 'package:option_result/option.dart';
-import 'package:option_result/result.dart';
 ```
 
 ## Basic Usage
@@ -354,12 +351,6 @@ import 'package:option_result/option_result.dart'
     OptionFutureOrUnwrap,
     ResultFutureUnwrap,
     ResultFutureOrUnwrap;
-
-// Or if you're only importing one of the types from the package:
-import 'package:option_result/option.dart'
-  hide
-    OptionFutureUnwrap,
-    OptionFutureOrUnwrap;
 ```
 
 ## Similar packages

--- a/lib/option_result.dart
+++ b/lib/option_result.dart
@@ -17,5 +17,5 @@
 /// ```
 library option_result;
 
-export 'option.dart';
-export 'result.dart';
+export 'src/option.dart';
+export 'src/result.dart';

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -18,8 +18,8 @@ import 'dart:async';
 
 import 'result.dart';
 
-import 'src/util.dart';
+import 'util.dart';
 
-part 'src/option/option.dart';
-part 'src/option/option_error.dart';
-part 'src/option/option_helpers.dart';
+part 'option/option.dart';
+part 'option/option_error.dart';
+part 'option/option_helpers.dart';

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -18,8 +18,8 @@ import 'dart:async';
 
 import 'option.dart';
 
-import 'src/util.dart';
+import 'util.dart';
 
-part 'src/result/result.dart';
-part 'src/result/result_error.dart';
-part 'src/result/result_helpers.dart';
+part 'result/result.dart';
+part 'result/result_error.dart';
+part 'result/result_helpers.dart';


### PR DESCRIPTION
I personally think that it does not make much sense to include multiple public libraries for this package since it is a relatively small one, especially since one is likely to use `Option` and `Result` together.
In general, I also think it is more intuitive if there is just one library to import a component of some package from.