### PR TITLE
Remove value getters, update docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Again, like `Option`, this helps promote clean, concise, and safe code.
 Result<int, String> multiplyBy5(int i) => Ok(i * 5);
 Result<int, String> divideBy2(int i) => switch (i) {
   0 => Err('divided by 0'),
-  _ => Ok(i ~/ 2)
+  _ => Ok(i ~/ 2),
 };
 
 Result<int, String> a = Ok(10);
@@ -123,8 +123,8 @@ Result<String, String> getUserEmailLowerCase(int id) => catchResult(() {
 Result<String, String> email = getUserEmailLowerCase(12345);
 
 switch (email) {
-  case Ok(value: String value): print('User email: $value');
-  case Err(value: String err): print('Error fetching email: $err');
+  case Ok(:String v): print('User email: $v');
+  case Err(:String e): print('Error fetching email: $e');
 }
 ```
 
@@ -145,7 +145,7 @@ Result<(), String> failableOperation() {
 
 Result<(), String> err = failableOperation();
 
-if (err case Err(value: String error)) {
+if (err case Err(e: String error)) {
   print(error);
   return;
 }
@@ -171,7 +171,7 @@ Result<(), String> err = await catchResultAsync(() async {
   return Ok(());
 });
 
-if (err case Err(value: String error)) {
+if (err case Err(e: String error)) {
   print(error);
   return;
 }
@@ -238,7 +238,7 @@ import 'package:option_result/result.dart';
 // Assume getUser() returns some sort of User object
 Result<User, String> user = await getUser(id: 12345);
 
-if (user case Err(value: String error)) {
+if (user case Err(e: String error)) {
   print('Error retrieving user: $error');
   return;
 }
@@ -246,7 +246,7 @@ if (user case Err(value: String error)) {
 // Assume the User object has an email field of type Option<String>
 Option<String> email = user.unwrap().email;
 
-if (email case Some(value: String address)) {
+if (email case Some(v: String address)) {
   print('User email: $address');
 } else {
   print('User has no email set.');
@@ -254,7 +254,7 @@ if (email case Some(value: String address)) {
 
 // Alternative to the above using a switch expression for pattern matching
 print(switch (email) {
-  Some(value: String address) => 'User email: $address',
+  Some(v: String address) => 'User email: $address',
   None() => 'User has no email set.'
 });
 
@@ -273,57 +273,27 @@ developers a little easier and this library provides a bit of its own sugar too.
 Consider the following if-case:
 
 ```dart
-if (result case Err(value: String value)) {}
+if (result case Err(e: String value)) {}
 ```
 
-This example checks if `result` is `Err` and that its `value` field contains a `String`
+This example checks if `result` is `Err` and that its `e` field contains a `String`
 type value, which it binds to the scoped variable of the same name, `value`.
 
-This level of verbosity is necessary if you want to rebind the `value` field to
+This level of verbosity is necessary if you want to rebind the `e` field to
 a scoped variable of a different name like so:
 
 ```dart
-if (result case Err(value: String foo)) {}
+if (result case Err(e: String foo)) {}
 ```
 
-But if you're comfortable with your scoped variable being named `value` then you can
+But if you're comfortable with your scoped variable being named `e` then you can
 make use of the field-access shorthand that Dart provides:
 
 ```dart
-if (result case Err(:String value)) {}
-if (result case Err(:final value)) {}
-if (result case Err(:var value)) {}
-```
-
-These are all functionally identical but the lack of repetition really cleans things up.
-
-To clean things up even further, the `Option` and `Result` types have a few shorthand
-getters you can take advantage of:
-
-```dart
-if (result case Ok(:var v)) {}
-if (result case Ok(:var val)) {}
+if (result case Err(:String e)) {}
+if (result case Err(:final e)) {}
 if (result case Err(:var e)) {}
-if (result case Err(:var error)) {}
-// Err types also have v, val
 ```
-
-These can also be used for rebinding:
-
-```dart
-if (result case Err(e: var foo)) {}
-```
-
-The exhaustive list of `value` field shorthand getters for `Option` and `Result`
-is as follows:
-
-- `Option`
-  - `Some`: `v`, `val`
-- `Result`
-  - `Ok`: `v`, `val`
-  - `Err`: `v`, `val`, `e`, `error`
-    - Ideally `err` would be included but is not possible due to the `err` method
-    found on `Result` types
 
 ## Potential extension conflicts
 

--- a/example/option_result_example.dart
+++ b/example/option_result_example.dart
@@ -5,51 +5,51 @@ import 'package:option_result/option_result.dart';
 Random random = Random();
 
 void main() async {
-	// Get a user object from the database
-	Result<User, String> user = await getUser(id: 12345);
+  // Get a user object from the database
+  Result<User, String> user = await getUser(id: 12345);
 
-	// If it's an Err type value, display the unwrapped error value and return
-	if (user case Err(value: String error)) {
-		print('Error retrieving user: $error');
-		return;
-	}
+  // If it's an Err type value, display the unwrapped error value and return
+  if (user case Err(e: String error)) {
+    print('Error retrieving user: $error');
+    return;
+  }
 
-	// Try getting the user's email address
-	Option<String> email = user.unwrap().email;
+  // Try getting the user's email address
+  Option<String> email = user.unwrap().email;
 
-	// If the user has an email address, print it
-	if (email case Some(value: String address)) {
-		print('User email: $address');
-	} else {
-		print('User has no email set');
-	}
+  // If the user has an email address, print it
+  if (email case Some(v: String address)) {
+    print('User email: $address');
+  } else {
+    print('User has no email set');
+  }
 
-	// Alternative to the above using a switch expression for pattern matching
-	String message = switch (email) {
-		Some(value: String address) => 'User email: $address',
-		None() => 'User has no email set'
-	};
+  // Alternative to the above using a switch expression for pattern matching
+  String message = switch (email) {
+    Some(v: String address) => 'User email: $address',
+    None() => 'User has no email set'
+  };
 
-	print(message);
+  print(message);
 }
 
 /// Represents a user in a database
 class User {
-	int id;
-	Option<String> email;
-	User(this.id, this.email);
+  int id;
+  Option<String> email;
+  User(this.id, this.email);
 }
 
 /// Simulate pulling a user from a database
 Future<Result<User, String>> getUser({required int id}) async {
-	await Future.delayed(Duration(milliseconds: 100));
+  await Future.delayed(Duration(milliseconds: 100));
 
-	int randInt = random.nextInt(3);
+  int randInt = random.nextInt(3);
 
-	return switch (randInt) {
-		0 => Ok(User(id, Some('foo$id@bar.com'))),
-		1 => Ok(User(id, None())),
-		2 => Err('User $id not found'),
-		_ => Err('Something went wrong')
-	};
+  return switch (randInt) {
+    0 => Ok(User(id, Some('foo$id@bar.com'))),
+    1 => Ok(User(id, None())),
+    2 => Err('User $id not found'),
+    _ => Err('Something went wrong')
+  };
 }

--- a/lib/src/option/option.dart
+++ b/lib/src/option/option.dart
@@ -8,7 +8,7 @@ part of option;
 /// Option<int> foo = Some(42);
 ///
 /// print(switch (foo) {
-///   Some(value: var bar) => 'Some value: $bar',
+///   Some(v: var bar) => 'Some value: $bar',
 ///   None() => 'No value!'
 /// });
 /// ```
@@ -16,373 +16,378 @@ part of option;
 /// See also:
 /// [Rust: `Option`](https://doc.rust-lang.org/std/option/enum.Option.html)
 sealed class Option<T> {
-	/// The `Option` class cannot be instantiated directly. use [Some()], [None()],
-	/// or [Option.from()] to create instances of `Option` variants.
-	const Option();
+  /// The `Option` class cannot be instantiated directly. use [Some()], [None()],
+  /// or [Option.from()] to create instances of `Option` variants.
+  const Option();
 
-	/// Creates an `Option` from the given nullable `T` value.
-	///
-	/// Creates:
-	/// - [Some] if the given value is not null.
-	/// - [None] if the given value is null.
-	factory Option.from(T? value) => switch (value) {
-		null => None(),
-		_ => Some(value)
-	};
+  /// Creates an `Option` from the given nullable `T` value.
+  ///
+  /// Creates:
+  /// - [Some] if the given value is not null.
+  /// - [None] if the given value is null.
+  factory Option.from(T? value) => switch (value) {
+        null => None(),
+        _ => Some(value),
+      };
 
-	@override
-	int get hashCode => switch (this) {
-		Some(:T v) => Object.hash('Some()', v),
-		None() => Object.hash('None()', runtimeType)
-	};
+  @override
+  int get hashCode => switch (this) {
+        Some(:T v) => Object.hash('Some()', v),
+        None() => Object.hash('None()', runtimeType)
+      };
 
-	/// Compare equality between two `Option` values.
-	///
-	/// `Option` values are considered equal if the values they hold are equal,
-	/// or if they hold references to the same object ([identical()]).
-	///
-	/// Note that [None] values are always equal to one another. Their `T` type
-	/// is elided implicitly.
-	@override
-	operator ==(Object other) => switch (other) {
-		Some(:T v) when isSome() => identical(v, unwrap()) || v == unwrap(),
-		None() when isNone() => true,
-		_ => false
-	};
+  /// Compare equality between two `Option` values.
+  ///
+  /// `Option` values are considered equal if the values they hold are equal,
+  /// or if they hold references to the same object ([identical()]).
+  ///
+  /// Note that [None] values are always equal to one another. Their `T` type
+  /// is elided implicitly.
+  @override
+  operator ==(Object other) => switch (other) {
+        Some(:T v) when isSome() => identical(v, unwrap()) || v == unwrap(),
+        None() when isNone() => true,
+        _ => false
+      };
 
-	@override
-	String toString() => switch (this) {
-		Some(:T v) => 'Some($v)',
-		None() => 'None()'
-	};
+  @override
+  String toString() => switch (this) {
+        Some(:T v) => 'Some($v)',
+        None() => 'None()',
+      };
 
-	/// Shortcut to call [Option.unwrap()].
-	///
-	/// Allows calling an `Option` value like a function as a shortcut to unwrap the
-	/// held value of the `Option`.
-	///
-	/// **Warning**: This is an *unsafe* operation. An [OptionError] will be thrown
-	/// if this operation is used on a [None] value. You can take advantage of this
-	/// safely via [catchOption]/[catchOptionAsync].
-	///
-	/// ```dart
-	/// var foo = Some(1);
-	/// var bar = Some(2);
-	///
-	/// print(foo() + bar()); // prints: 3
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Option::unwrap()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
-	T call() => unwrap();
+  /// Shortcut to call [Option.unwrap()].
+  ///
+  /// Allows calling an `Option` value like a function as a shortcut to unwrap the
+  /// held value of the `Option`.
+  ///
+  /// **Warning**: This is an *unsafe* operation. An [OptionError] will be thrown
+  /// if this operation is used on a [None] value. You can take advantage of this
+  /// safely via [catchOption]/[catchOptionAsync].
+  ///
+  /// ```dart
+  /// var foo = Some(1);
+  /// var bar = Some(2);
+  ///
+  /// print(foo() + bar()); // prints: 3
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Option::unwrap()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
+  T call() => unwrap();
 
-	/// Returns whether or not this `Option` holds a value ([Some]).
-	///
-	/// See also:
-	/// [Rust: `Option::is_some()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some)
-	bool isSome() => switch (this) {
-		Some() => true,
-		None() => false
-	};
+  /// Returns whether or not this `Option` holds a value ([Some]).
+  ///
+  /// See also:
+  /// [Rust: `Option::is_some()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some)
+  bool isSome() => switch (this) {
+        Some() => true,
+        None() => false,
+      };
 
-	/// Returns whether or not this `Option` holds a value ([Some]) and the held
-	/// value matches the given predicate.
-	///
-	/// Returns:
-	/// - `true` if this `Option` is [Some] and `predicate` returns `true`.
-	/// - `false` if this `Option` is [None], or `predicate` returns `false`
-	///
-	/// See also:
-	/// [Rust: `Option::is_some_and()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some_and)
-	bool isSomeAnd(bool Function(T) predicate) => switch (this) {
-		Some(:T v) => predicate(v),
-		None() => false
-	};
+  /// Returns whether or not this `Option` holds a value ([Some]) and the held
+  /// value matches the given predicate.
+  ///
+  /// Returns:
+  /// - `true` if this `Option` is [Some] and `predicate` returns `true`.
+  /// - `false` if this `Option` is [None], or `predicate` returns `false`
+  ///
+  /// See also:
+  /// [Rust: `Option::is_some_and()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some_and)
+  bool isSomeAnd(bool Function(T) predicate) => switch (this) {
+        Some(:T v) => predicate(v),
+        None() => false,
+      };
 
-	/// Returns whether or not this `Option` holds no value ([None]).
-	///
-	/// See also:
-	/// [Rust: `Option::is_none()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none)
-	bool isNone() => !isSome();
+  /// Returns whether or not this `Option` holds no value ([None]).
+  ///
+  /// See also:
+  /// [Rust: `Option::is_none()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none)
+  bool isNone() => !isSome();
 
-	/// Returns the held value of this `Option` if it is [Some].
-	///
-	/// **Warning**: This method is *unsafe*. An [OptionError] will be thrown when
-	/// this method is called if this `Option` is [None].
-	///
-	/// See also:
-	/// [Rust: `Option::unwrap()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
-	T unwrap() => switch (this) {
-		Some(:T v) => v,
-		None() => throw OptionError('called `Option#unwrap()` on a `None` value')
-	};
+  /// Returns the held value of this `Option` if it is [Some].
+  ///
+  /// **Warning**: This method is *unsafe*. An [OptionError] will be thrown when
+  /// this method is called if this `Option` is [None].
+  ///
+  /// See also:
+  /// [Rust: `Option::unwrap()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
+  T unwrap() => switch (this) {
+        Some(:T v) => v,
+        None() =>
+          throw OptionError('called `Option#unwrap()` on a `None` value'),
+      };
 
-	/// Returns the held value of this `Option` if it is [Some], or the given value
-	/// if this `Option` is [None].
-	///
-	/// See also:
-	/// [Rust: `Option::unwrap_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or)
-	T unwrapOr(T orValue) => switch (this) {
-		Some(:T v) => v,
-		None() => orValue
-	};
+  /// Returns the held value of this `Option` if it is [Some], or the given value
+  /// if this `Option` is [None].
+  ///
+  /// See also:
+  /// [Rust: `Option::unwrap_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or)
+  T unwrapOr(T orValue) => switch (this) {
+        Some(:T v) => v,
+        None() => orValue,
+      };
 
-	/// Returns the held value of this `Option` if it is [Some], or returns the
-	/// returned value from `elseFn` if this `Option` is [None].
-	///
-	/// See also:
-	/// [Rust: `Option::unwrap_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or_else)
-	T unwrapOrElse(T Function() elseFn) => switch (this) {
-		Some(:T v) => v,
-		None() => elseFn()
-	};
+  /// Returns the held value of this `Option` if it is [Some], or returns the
+  /// returned value from `elseFn` if this `Option` is [None].
+  ///
+  /// See also:
+  /// [Rust: `Option::unwrap_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or_else)
+  T unwrapOrElse(T Function() elseFn) => switch (this) {
+        Some(:T v) => v,
+        None() => elseFn(),
+      };
 
-	/// Returns the held value of this `Option` if it is [Some], or throws [OptionError]
-	/// with the given `message` if this `Option` is [None].
-	///
-	/// See also:
-	/// [Rust: `Option::expect()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.expect)
-	T expect(String message) => switch (this) {
-		Some(:T v) => v,
-		None() => throw OptionError(message, isExpected: true)
-	};
+  /// Returns the held value of this `Option` if it is [Some], or throws [OptionError]
+  /// with the given `message` if this `Option` is [None].
+  ///
+  /// See also:
+  /// [Rust: `Option::expect()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.expect)
+  T expect(String message) => switch (this) {
+        Some(:T v) => v,
+        None() => throw OptionError(message, isExpected: true),
+      };
 
-	/// Returns an [Iterable] of the held value.
-	///
-	/// Yields:
-	/// - The held `T` value if [Some].
-	/// - Nothing if [None].
-	///
-	/// See also:
-	/// [Rust: `Option::iter()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.iter)
-	Iterable<T> iter() sync* {
-		switch (this) {
-			case Some(:T v): yield v;
-			case None(): return;
-		}
-	}
+  /// Returns an [Iterable] of the held value.
+  ///
+  /// Yields:
+  /// - The held `T` value if [Some].
+  /// - Nothing if [None].
+  ///
+  /// See also:
+  /// [Rust: `Option::iter()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.iter)
+  Iterable<T> iter() sync* {
+    switch (this) {
+      case Some(:T v):
+        yield v;
+      case None():
+        return;
+    }
+  }
 
-	/// Returns [None<U>] if this `Option` is [None<T>], otherwise returns `other`.
-	///
-	/// See also:
-	/// [Rust: `Option::and()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and)
-	Option<U> and<U>(Option<U> other) => switch (this) {
-		Some() => other,
-		None() => None()
-	};
+  /// Returns [None<U>] if this `Option` is [None<T>], otherwise returns `other`.
+  ///
+  /// See also:
+  /// [Rust: `Option::and()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and)
+  Option<U> and<U>(Option<U> other) => switch (this) {
+        Some() => other,
+        None() => None(),
+      };
 
-	/// Returns [None<U>] if this `Option` is [None<T>], otherwise calls `fn` with
-	/// the held value and returns the returned `Option`.
-	///
-	/// See also:
-	/// [Rust: `Option::and_then()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then)
-	Option<U> andThen<U>(Option<U> Function(T) fn) => switch (this) {
-		Some(:T v) => fn(v),
-		None() => None()
-	};
+  /// Returns [None<U>] if this `Option` is [None<T>], otherwise calls `fn` with
+  /// the held value and returns the returned `Option`.
+  ///
+  /// See also:
+  /// [Rust: `Option::and_then()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then)
+  Option<U> andThen<U>(Option<U> Function(T) fn) => switch (this) {
+        Some(:T v) => fn(v),
+        None() => None(),
+      };
 
-	/// Returns this `Option` if this `Option` is [Some<T>], otherwise returns `other`.
-	///
-	/// See also:
-	/// [Rust: `Option::or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.or)
-	Option<T> or(Option<T> other) => switch (this) {
-		Some() => this,
-		None() => other
-	};
+  /// Returns this `Option` if this `Option` is [Some<T>], otherwise returns `other`.
+  ///
+  /// See also:
+  /// [Rust: `Option::or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.or)
+  Option<T> or(Option<T> other) => switch (this) {
+        Some() => this,
+        None() => other,
+      };
 
-	/// Returns this `Option` if this `Option` is [Some<T>], otherwise calls `fn`
-	/// and returns the returned `Option`.
-	///
-	/// See also:
-	/// [Rust: `Option::or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.or_else)
-	Option<T> orElse(Option<T> Function() fn) => switch (this) {
-		Some() => this,
-		None() => fn()
-	};
+  /// Returns this `Option` if this `Option` is [Some<T>], otherwise calls `fn`
+  /// and returns the returned `Option`.
+  ///
+  /// See also:
+  /// [Rust: `Option::or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.or_else)
+  Option<T> orElse(Option<T> Function() fn) => switch (this) {
+        Some() => this,
+        None() => fn(),
+      };
 
-	/// Returns [Some] if exactly one of this `Option` and `other` is [Some], otherwise
-	/// returns [None].
-	///
-	/// Returns:
-	/// - This `Option` if this `Option` is [Some] and `other` is [None].
-	/// - `other` if this `Option` is [None] and `other` is [Some].
-	/// - [None] otherwise.
-	///
-	/// See also:
-	/// [Rust: `Option::xor()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.xor)
-	Option<T> xor(Option<T> other) => switch ((this, other)) {
-		(Some(), None()) => this,
-		(None(), Some()) => other,
-		_ => None()
-	};
+  /// Returns [Some] if exactly one of this `Option` and `other` is [Some], otherwise
+  /// returns [None].
+  ///
+  /// Returns:
+  /// - This `Option` if this `Option` is [Some] and `other` is [None].
+  /// - `other` if this `Option` is [None] and `other` is [Some].
+  /// - [None] otherwise.
+  ///
+  /// See also:
+  /// [Rust: `Option::xor()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.xor)
+  Option<T> xor(Option<T> other) => switch ((this, other)) {
+        (Some(), None()) => this,
+        (None(), Some()) => other,
+        _ => None()
+      };
 
-	/// Calls the provided function with the contained value if this `Option` is [Some].
-	///
-	/// Returns this `Option`.
-	///
-	/// ```dart
-	/// Option<int> foo = Some(1);
-	///
-	/// int bar = foo
-	///   .map((value) => value + 2)
-	///   .inspect((value) => print(value)) // prints: 3
-	///   .unwrap();
-	///
-	/// print(bar); // prints: 3
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Option::inspect()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.inspect)
-	Option<T> inspect(void Function(T) fn) {
-		if (this case Some(:T v)) {
-			fn(v);
-		}
+  /// Calls the provided function with the contained value if this `Option` is [Some].
+  ///
+  /// Returns this `Option`.
+  ///
+  /// ```dart
+  /// Option<int> foo = Some(1);
+  ///
+  /// int bar = foo
+  ///   .map((value) => value + 2)
+  ///   .inspect((value) => print(value)) // prints: 3
+  ///   .unwrap();
+  ///
+  /// print(bar); // prints: 3
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Option::inspect()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.inspect)
+  Option<T> inspect(void Function(T) fn) {
+    if (this case Some(:T v)) {
+      fn(v);
+    }
 
-		return this;
-	}
+    return this;
+  }
 
-	/// Filters this `Option` based on the given `predicate` function.
-	///
-	/// Returns [None] if this `Option` is [None], otherwise calls `predicate` with
-	/// the held value, returning:
-	///
-	/// - [Some<T>] if `predicate` returns `true`.
-	/// - [None<T>] if `predicate` returns `false`.
-	///
-	/// See also:
-	/// [Rust: `Option::filter()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.filter)
-	Option<T> where(bool Function(T) predicate) => switch (this) {
-		Some(:T v) => predicate(v) ? this : None(),
-		None() => this
-	};
+  /// Filters this `Option` based on the given `predicate` function.
+  ///
+  /// Returns [None] if this `Option` is [None], otherwise calls `predicate` with
+  /// the held value, returning:
+  ///
+  /// - [Some<T>] if `predicate` returns `true`.
+  /// - [None<T>] if `predicate` returns `false`.
+  ///
+  /// See also:
+  /// [Rust: `Option::filter()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.filter)
+  Option<T> where(bool Function(T) predicate) => switch (this) {
+        Some(:T v) => predicate(v) ? this : None(),
+        None() => this,
+      };
 
-	/// Maps this `Option<T>` to an `Option<U>` using the given function with the
-	/// held value.
-	///
-	/// Returns:
-	/// - [Some<U>] if this `Option` is [Some<T>].
-	/// - [None<U>] if this `Option` is [None].
-	///
-	/// See also:
-	/// [Rust: `Option::map()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map)
-	Option<U> map<U>(U Function(T) mapFn) => switch (this) {
-		Some(:T v) => Some(mapFn(v)),
-		None() => None()
-	};
+  /// Maps this `Option<T>` to an `Option<U>` using the given function with the
+  /// held value.
+  ///
+  /// Returns:
+  /// - [Some<U>] if this `Option` is [Some<T>].
+  /// - [None<U>] if this `Option` is [None].
+  ///
+  /// See also:
+  /// [Rust: `Option::map()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map)
+  Option<U> map<U>(U Function(T) mapFn) => switch (this) {
+        Some(:T v) => Some(mapFn(v)),
+        None() => None(),
+      };
 
-	/// Maps this `Option<T>` to an `Option<U>` using the given function with the
-	/// held value if this `Option<T>` is [Some]. Otherwise returns the provided
-	/// `orValue` as `Some(orValue)`.
-	///
-	/// Values passed for `orValue` are eagerly evaluated. Consider using [Option.mapOrElse()]
-	/// to provide a default that will not be evaluated unless this `Option` is [None].
-	///
-	/// ```dart
-	/// Option<int> a = Some(1);
-	/// Option<int> b = None();
-	///
-	/// print(a.mapOr(5, (val) => val + 1).unwrap()); // prints: 2
-	/// print(b.mapOr(5, (val) => val + 1).unwrap()); // prints: 5
-	/// ```
-	///
-	/// **Note**: Unlike Rust's
-	/// [Option::map_or()](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or),
-	/// this method returns an `Option` value. Given that [Option.map()] returns
-	/// the mapped `Option` it just made sense for this method to do the same.
-	///
-	/// See also:
-	/// [Rust: `Option::map_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or)
-	Option<U> mapOr<U>(U orValue, U Function(T) mapFn) => switch (this) {
-		Some(:T v) => Some(mapFn(v)),
-		None() => Some(orValue)
-	};
+  /// Maps this `Option<T>` to an `Option<U>` using the given function with the
+  /// held value if this `Option<T>` is [Some]. Otherwise returns the provided
+  /// `orValue` as `Some(orValue)`.
+  ///
+  /// Values passed for `orValue` are eagerly evaluated. Consider using [Option.mapOrElse()]
+  /// to provide a default that will not be evaluated unless this `Option` is [None].
+  ///
+  /// ```dart
+  /// Option<int> a = Some(1);
+  /// Option<int> b = None();
+  ///
+  /// print(a.mapOr(5, (val) => val + 1).unwrap()); // prints: 2
+  /// print(b.mapOr(5, (val) => val + 1).unwrap()); // prints: 5
+  /// ```
+  ///
+  /// **Note**: Unlike Rust's
+  /// [Option::map_or()](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or),
+  /// this method returns an `Option` value. Given that [Option.map()] returns
+  /// the mapped `Option` it just made sense for this method to do the same.
+  ///
+  /// See also:
+  /// [Rust: `Option::map_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or)
+  Option<U> mapOr<U>(U orValue, U Function(T) mapFn) => switch (this) {
+        Some(:T v) => Some(mapFn(v)),
+        None() => Some(orValue),
+      };
 
-	/// Maps this `Option<T>` to an `Option<U>` using the given `mapFn` function with
-	/// the held value if this `Option` is [Some]. Otherwise returns the result of
-	/// `orFn` as `Some(orFn())`.
-	///
-	/// `orFn` will only be evaluated if this `Option` is [None].
-	///
-	/// ```dart
-	/// Option<int> a = Some(1);
-	/// Option<int> b = None();
-	///
-	/// print(a.mapOrElse(() => 5, (val) => val + 1).unwrap()); // prints: 2
-	/// print(b.mapOrElse(() => 5, (val) => val + 1).unwrap()); // prints: 5
-	/// ```
-	///
-	/// **Note**: Unlike Rust's
-	/// [Option::map_or_else()](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or_else),
-	/// this method returns an `Option` value. Given that [Option.map()] returns
-	/// the mapped `Option` it just made sense for this method to do the same.
-	///
-	/// See also:
-	/// [Rust: `Option::map_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or_else)
-	Option<U> mapOrElse<U>(U Function() orFn, U Function(T) mapFn) => switch (this) {
-		Some(:T v) => Some(mapFn(v)),
-		None() => Some(orFn())
-	};
+  /// Maps this `Option<T>` to an `Option<U>` using the given `mapFn` function with
+  /// the held value if this `Option` is [Some]. Otherwise returns the result of
+  /// `orFn` as `Some(orFn())`.
+  ///
+  /// `orFn` will only be evaluated if this `Option` is [None].
+  ///
+  /// ```dart
+  /// Option<int> a = Some(1);
+  /// Option<int> b = None();
+  ///
+  /// print(a.mapOrElse(() => 5, (val) => val + 1).unwrap()); // prints: 2
+  /// print(b.mapOrElse(() => 5, (val) => val + 1).unwrap()); // prints: 5
+  /// ```
+  ///
+  /// **Note**: Unlike Rust's
+  /// [Option::map_or_else()](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or_else),
+  /// this method returns an `Option` value. Given that [Option.map()] returns
+  /// the mapped `Option` it just made sense for this method to do the same.
+  ///
+  /// See also:
+  /// [Rust: `Option::map_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or_else)
+  Option<U> mapOrElse<U>(U Function() orFn, U Function(T) mapFn) =>
+      switch (this) {
+        Some(:T v) => Some(mapFn(v)),
+        None() => Some(orFn()),
+      };
 
-	/// Zips this `Option` with another `Option`, returning a [Record] of their
-	/// held values.
-	///
-	/// Returns:
-	/// - [Some<(T, U)>] if this `Option` is [Some<T>] and `other` is [Some<U>].
-	/// - [None<(T, U)>] otherwise.
-	///
-	/// See: [OptionUnzip.unzip()] for reversing this operation.
-	///
-	/// See also:
-	/// [Rust: `Option::zip()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.zip)
-	Option<(T, U)> zip<U>(Option<U> other) => switch ((this, other)) {
-		(Some(v: T a), Some(v: U b)) => Some((a, b)),
-		_ => None()
-	};
+  /// Zips this `Option` with another `Option`, returning a [Record] of their
+  /// held values.
+  ///
+  /// Returns:
+  /// - [Some<(T, U)>] if this `Option` is [Some<T>] and `other` is [Some<U>].
+  /// - [None<(T, U)>] otherwise.
+  ///
+  /// See: [OptionUnzip.unzip()] for reversing this operation.
+  ///
+  /// See also:
+  /// [Rust: `Option::zip()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.zip)
+  Option<(T, U)> zip<U>(Option<U> other) => switch ((this, other)) {
+        (Some(v: T a), Some(v: U b)) => Some((a, b)),
+        _ => None(),
+      };
 
-	/// Zips this `Option` with another `Option` using the given function.
-	///
-	/// Returns:
-	/// - [Some<V>] if this `Option` is [Some<T>] and `other` is [Some<U>].
-	/// - [None<V>] otherwise.
-	///
-	/// See also:
-	/// [Rust: `Option::zip_with()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.zip_with)
-	Option<V> zipWith<U, V>(Option<U> other, V Function(T, U) zipFn) => switch ((this, other)) {
-		(Some(v: T a), Some(v: U b)) => Some(zipFn(a, b)),
-		_ => None()
-	};
+  /// Zips this `Option` with another `Option` using the given function.
+  ///
+  /// Returns:
+  /// - [Some<V>] if this `Option` is [Some<T>] and `other` is [Some<U>].
+  /// - [None<V>] otherwise.
+  ///
+  /// See also:
+  /// [Rust: `Option::zip_with()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.zip_with)
+  Option<V> zipWith<U, V>(Option<U> other, V Function(T, U) zipFn) =>
+      switch ((this, other)) {
+        (Some(v: T a), Some(v: U b)) => Some(zipFn(a, b)),
+        _ => None(),
+      };
 
-	/// Converts this `Option<T>` into a [Result<T, E>] using the given `err` if [None].
-	///
-	/// Values passed for `err` are eagerly evaluated. Consider using [Option.okOrElse()]
-	/// to provide an error value that will not be evaluated unless this `Option` is [None].
-	///
-	/// Returns:
-	/// - [Ok<T, E>] if this `Option` is [Some<T>].
-	/// - [Err<T, E>] using `err` if this `Option` is [None<T>].
-	///
-	/// See also:
-	/// [Rust: `Option::ok_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or)
-	Result<T, E> okOr<E>(E err) => switch (this) {
-		Some(:T v) => Ok(v),
-		None() => Err(err)
-	};
+  /// Converts this `Option<T>` into a [Result<T, E>] using the given `err` if [None].
+  ///
+  /// Values passed for `err` are eagerly evaluated. Consider using [Option.okOrElse()]
+  /// to provide an error value that will not be evaluated unless this `Option` is [None].
+  ///
+  /// Returns:
+  /// - [Ok<T, E>] if this `Option` is [Some<T>].
+  /// - [Err<T, E>] using `err` if this `Option` is [None<T>].
+  ///
+  /// See also:
+  /// [Rust: `Option::ok_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or)
+  Result<T, E> okOr<E>(E err) => switch (this) {
+        Some(:T v) => Ok(v),
+        None() => Err(err),
+      };
 
-	/// Converts this `Option<T>` into a [Result<T, E>] using the returned value
-	/// from `elseFn` if [None].
-	///
-	/// `elseFn` will only be evaluated if this `Option` is [None].
-	///
-	/// Returns:
-	/// - [Ok<T, E>] if this `Option` is [Some<T>].
-	/// - [Err<T, E>] using the value returned by `elseFn` if this `Option` is [None<T>].
-	///
-	/// See also:
-	/// [Rust: `Option::ok_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or_else)
-	Result<T, E> okOrElse<E>(E Function() elseFn) => switch (this) {
-		Some(:T v) => Ok(v),
-		None() => Err(elseFn())
-	};
+  /// Converts this `Option<T>` into a [Result<T, E>] using the returned value
+  /// from `elseFn` if [None].
+  ///
+  /// `elseFn` will only be evaluated if this `Option` is [None].
+  ///
+  /// Returns:
+  /// - [Ok<T, E>] if this `Option` is [Some<T>].
+  /// - [Err<T, E>] using the value returned by `elseFn` if this `Option` is [None<T>].
+  ///
+  /// See also:
+  /// [Rust: `Option::ok_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or_else)
+  Result<T, E> okOrElse<E>(E Function() elseFn) => switch (this) {
+        Some(:T v) => Ok(v),
+        None() => Err(elseFn()),
+      };
 }
 
 /// A type that represents the presence of a value of type `T`.
@@ -392,17 +397,14 @@ sealed class Option<T> {
 /// ```dart
 /// Option<int> foo = Some(42);
 ///
-/// if (foo case Some(value: var bar)) {
+/// if (foo case Some(v: var bar)) {
 ///   print(bar);
 /// }
 /// ```
 class Some<T> extends Option<T> {
-	final T value;
+  final T v;
 
-	const Some(this.value);
-
-	T get v => value;
-	T get val => value;
+  const Some(this.v);
 }
 
 /// A type that represents the absence of a value.
@@ -417,109 +419,109 @@ class Some<T> extends Option<T> {
 /// }
 /// ```
 class None<T> extends Option<T> {
-	const None();
+  const None();
 }
 
 /// Provides the `unzip()` method to [Option] type values that hold a [Record] of two values.
 extension OptionUnzip<T, U> on Option<(T, U)> {
-	/// Unzips this `Option` if this `Option` holds a [Record] of two values.
-	///
-	/// Returns:
-	/// - `(Some<U>, Some<V>)` if this `Option` is [Some<(U, V)>].
-	/// - `(None<U>, None<V>)` if this `Option` is [None<(U, V)>].
-	///
-	/// See also:
-	/// [Rust: `Option::unzip()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unzip)
-	(Option<T>, Option<U>) unzip() => switch (this) {
-		Some(v: (T a, U b)) => (Some(a), Some(b)),
-		None() => (None(), None())
-	};
+  /// Unzips this `Option` if this `Option` holds a [Record] of two values.
+  ///
+  /// Returns:
+  /// - `(Some<U>, Some<V>)` if this `Option` is [Some<(U, V)>].
+  /// - `(None<U>, None<V>)` if this `Option` is [None<(U, V)>].
+  ///
+  /// See also:
+  /// [Rust: `Option::unzip()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unzip)
+  (Option<T>, Option<U>) unzip() => switch (this) {
+        Some(v: (T a, U b)) => (Some(a), Some(b)),
+        None() => (None(), None()),
+      };
 }
 
 /// Provides the `flatten()` method to [Option] type values that hold another [Option].
 extension OptionFlatten<T> on Option<Option<T>> {
-	/// Flattens a nested `Option` type value one level.
-	///
-	/// Returns:
-	/// - [Some<T>] if this `Option` is [Some<Option<T>>].
-	/// - [None<T>] if this `Option` is [None<Option<T>>].
-	///
-	/// See also:
-	/// [Rust: `Option::flatten()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)
-	Option<T> flatten() => andThen(identity);
+  /// Flattens a nested `Option` type value one level.
+  ///
+  /// Returns:
+  /// - [Some<T>] if this `Option` is [Some<Option<T>>].
+  /// - [None<T>] if this `Option` is [None<Option<T>>].
+  ///
+  /// See also:
+  /// [Rust: `Option::flatten()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)
+  Option<T> flatten() => andThen(identity);
 }
 
 /// Provides the `transpose()` method to [Option] type values that hold a [Result].
 extension OptionTranspose<T, E> on Option<Result<T, E>> {
-	/// Transposes this [Option<Result<T, E>>] into a [Result<Option<T>, E>].
-	///
-	/// Returns:
-	/// - [Ok<Some<T>, E>] if this `Option` is [Some<Ok<T, E>>].
-	/// - [Err<T, E>] if this `Option` is [Some<Err<T, E>>].
-	/// - [Ok<None<T>, E>] if this `Option` is [None<Result<T, E>>].
-	///
-	/// ```dart
-	/// Option<Result<int, String>> a = Some(Ok(1));
-	/// Result<Option<int>, String> b = Ok(Some(1));
-	///
-	/// print(a.transpose() == b); // prints: true
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Option::transpose()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.transpose)
-	Result<Option<T>, E> transpose() => switch (this) {
-		Some(v: Ok(:T v)) => Ok(Some(v)),
-		Some(v: Err(:E e)) => Err(e),
-		None() => Ok(None())
-	};
+  /// Transposes this [Option<Result<T, E>>] into a [Result<Option<T>, E>].
+  ///
+  /// Returns:
+  /// - [Ok<Some<T>, E>] if this `Option` is [Some<Ok<T, E>>].
+  /// - [Err<T, E>] if this `Option` is [Some<Err<T, E>>].
+  /// - [Ok<None<T>, E>] if this `Option` is [None<Result<T, E>>].
+  ///
+  /// ```dart
+  /// Option<Result<int, String>> a = Some(Ok(1));
+  /// Result<Option<int>, String> b = Ok(Some(1));
+  ///
+  /// print(a.transpose() == b); // prints: true
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Option::transpose()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.transpose)
+  Result<Option<T>, E> transpose() => switch (this) {
+        Some(v: Ok(:T v)) => Ok(Some(v)),
+        Some(v: Err(:E e)) => Err(e),
+        None() => Ok(None())
+      };
 }
 
 /// Provides `call` functionality to [Future] values that complete with an [Option]
 /// type value.
 extension OptionFutureUnwrap<T> on Future<Option<T>> {
-	/// Allows calling a `Future<Option<T>>` value like a function, transforming it
-	/// into a Future that unwraps the returned `Option` value.
-	///
-	/// **Warning**: This is an *unsafe* operation. An [OptionError] will be thrown
-	/// if this operation is used on a [Future] returning a [None] value when that
-	/// [Future] completes. You can take advantage of this safely via [catchOptionAsync].
-	///
-	/// ```dart
-	/// Future<Option<int>> optionReturn() async {
-	///   return Some(1);
-	/// }
-	///
-	/// int foo = await optionReturn()();
-	///
-	/// print(foo) // prints: 1
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Option::unwrap()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
-	Future<T> call() async => (await this).unwrap();
+  /// Allows calling a `Future<Option<T>>` value like a function, transforming it
+  /// into a Future that unwraps the returned `Option` value.
+  ///
+  /// **Warning**: This is an *unsafe* operation. An [OptionError] will be thrown
+  /// if this operation is used on a [Future] returning a [None] value when that
+  /// [Future] completes. You can take advantage of this safely via [catchOptionAsync].
+  ///
+  /// ```dart
+  /// Future<Option<int>> optionReturn() async {
+  ///   return Some(1);
+  /// }
+  ///
+  /// int foo = await optionReturn()();
+  ///
+  /// print(foo) // prints: 1
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Option::unwrap()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
+  Future<T> call() async => (await this).unwrap();
 }
 
 /// Provides `call` functionality to [FutureOr] values that complete with an [Option]
 /// type value.
 extension OptionFutureOrUnwrap<T> on FutureOr<Option<T>> {
-	/// Allows calling a `FutureOr<Option<T>>` value like a function, transforming it
-	/// into a Future that unwraps the returned `Option` value.
-	///
-	/// **Warning**: This is an *unsafe* operation. An [OptionError] will be thrown
-	/// if this operation is used on a [FutureOr] returning a [None] value when that
-	/// [FutureOr] completes. You can take advantage of this safely via [catchOptionAsync].
-	///
-	/// ```dart
-	/// FutureOr<Option<int>> optionReturn() {
-	///   return Some(1);
-	/// }
-	///
-	/// int foo = await optionReturn()();
-	///
-	/// print(foo) // prints: 1
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Option::unwrap()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
-	Future<T> call() async => (await this).unwrap();
+  /// Allows calling a `FutureOr<Option<T>>` value like a function, transforming it
+  /// into a Future that unwraps the returned `Option` value.
+  ///
+  /// **Warning**: This is an *unsafe* operation. An [OptionError] will be thrown
+  /// if this operation is used on a [FutureOr] returning a [None] value when that
+  /// [FutureOr] completes. You can take advantage of this safely via [catchOptionAsync].
+  ///
+  /// ```dart
+  /// FutureOr<Option<int>> optionReturn() {
+  ///   return Some(1);
+  /// }
+  ///
+  /// int foo = await optionReturn()();
+  ///
+  /// print(foo) // prints: 1
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Option::unwrap()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
+  Future<T> call() async => (await this).unwrap();
 }

--- a/lib/src/result/result.dart
+++ b/lib/src/result/result.dart
@@ -10,397 +10,406 @@ part of result;
 /// Result<int, String> foo = Ok(42);
 ///
 /// print(switch (foo) {
-///   Ok(value: var bar) => 'Ok value: $bar',
-///   Err(value: var err) => 'Error value: $err'
+///   Ok(v: var bar) => 'Ok value: $bar',
+///   Err(e: var err) => 'Error value: $err',
 /// });
 /// ```
 ///
 /// See also:
 /// [Rust: `Result`](https://doc.rust-lang.org/std/result/enum.Result.html)
 sealed class Result<T, E> {
-	/// The `Result` class cannot be instantiated directly. use [Ok()], [Err()],
-	/// or [Result.from()] to create instances of `Result` variants.
-	const Result();
+  /// The `Result` class cannot be instantiated directly. use [Ok()], [Err()],
+  /// or [Result.from()] to create instances of `Result` variants.
+  const Result();
 
-	/// Creates a `Result` from the given nullable `T` value.
-	///
-	/// Creates:
-	/// - [Ok] using the given `T` value if the given `T` value is not null.
-	/// - [Err] using the given `E` value if the given `T` value is null.
-	factory Result.from(T? value, E error) => switch (value) {
-		null => Err(error),
-		_ => Ok(value)
-	};
+  /// Creates a `Result` from the given nullable `T` value.
+  ///
+  /// Creates:
+  /// - [Ok] using the given `T` value if the given `T` value is not null.
+  /// - [Err] using the given `E` value if the given `T` value is null.
+  factory Result.from(T? value, E error) => switch (value) {
+        null => Err(error),
+        _ => Ok(value),
+      };
 
-	@override
-	int get hashCode => switch (this) {
-		Ok(:T v) => Object.hash('Ok()', v),
-		Err(:E e) => Object.hash('Err()', e)
-	};
+  @override
+  int get hashCode => switch (this) {
+        Ok(:T v) => Object.hash('Ok()', v),
+        Err(:E e) => Object.hash('Err()', e),
+      };
 
-	/// Compare equality between two `Result` values.
-	///
-	/// `Result` values are considered equal if the values they hold are equal,
-	/// or if they hold references to the same object ([identical()]). When comparing
-	/// [Ok] values, the type of `E` will be elided, and `T` will be elided when
-	/// comparing [Err] values.
-	///
-	/// This means that [Ok<int, String>(1)] is equal to [Ok<int, int>(1)] and
-	/// [Err<int, String>('foo')] is equal to [Err<bool, String>('foo')] because
-	/// their held values are equatable and their irrelevant types are elided.
-	@override
-	operator ==(Object other) => switch (other) {
-		Ok(:T v) when isOk() => identical(v, unwrap()) || v == unwrap(),
-		Err(:E e) when isErr() => identical(e, unwrapErr()) || e == unwrapErr(),
-		_ => false
-	};
+  /// Compare equality between two `Result` values.
+  ///
+  /// `Result` values are considered equal if the values they hold are equal,
+  /// or if they hold references to the same object ([identical()]). When comparing
+  /// [Ok] values, the type of `E` will be elided, and `T` will be elided when
+  /// comparing [Err] values.
+  ///
+  /// This means that [Ok<int, String>(1)] is equal to [Ok<int, int>(1)] and
+  /// [Err<int, String>('foo')] is equal to [Err<bool, String>('foo')] because
+  /// their held values are equatable and their irrelevant types are elided.
+  @override
+  operator ==(Object other) => switch (other) {
+        Ok(:T v) when isOk() => identical(v, unwrap()) || v == unwrap(),
+        Err(:E e) when isErr() => identical(e, unwrapErr()) || e == unwrapErr(),
+        _ => false,
+      };
 
-	@override
-	String toString() => switch (this) {
-		Ok(:T v) => 'Ok($v)',
-		Err(:E e) => 'Err($e)'
-	};
+  @override
+  String toString() => switch (this) {
+        Ok(:T v) => 'Ok($v)',
+        Err(:E e) => 'Err($e)',
+      };
 
-	/// Shortcut to call [Result.unwrap()].
-	///
-	/// Allows calling a `Result` value like a function as a shortcut to unwrap the
-	/// held value of the `Result`.
-	///
-	/// **Warning**: This is an *unsafe* operation. A [ResultError] will be thrown
-	/// if this operation is used on an [Err] value. You can take advantage of this
-	/// safely via [catchResult]/[catchResultAsync].
-	///
-	/// ```dart
-	/// var foo = Ok(1);
-	/// var bar = Ok(2);
-	///
-	/// print(foo() + bar()); // prints: 3
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Result::unwrap()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
-	T call() => unwrap();
+  /// Shortcut to call [Result.unwrap()].
+  ///
+  /// Allows calling a `Result` value like a function as a shortcut to unwrap the
+  /// held value of the `Result`.
+  ///
+  /// **Warning**: This is an *unsafe* operation. A [ResultError] will be thrown
+  /// if this operation is used on an [Err] value. You can take advantage of this
+  /// safely via [catchResult]/[catchResultAsync].
+  ///
+  /// ```dart
+  /// var foo = Ok(1);
+  /// var bar = Ok(2);
+  ///
+  /// print(foo() + bar()); // prints: 3
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Result::unwrap()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
+  T call() => unwrap();
 
-	/// Returns whether or not this `Result` is [Ok].
-	///
-	/// See also:
-	/// [Rust: `Result::is_ok()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok)
-	bool isOk() => switch (this) {
-		Ok() => true,
-		Err() => false,
-	};
+  /// Returns whether or not this `Result` is [Ok].
+  ///
+  /// See also:
+  /// [Rust: `Result::is_ok()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok)
+  bool isOk() => switch (this) {
+        Ok() => true,
+        Err() => false,
+      };
 
-	/// Returns whether or not this `Result` is [Ok] and that the held value matches
-	/// the given predicate.
-	///
-	/// Returns:
-	/// - `true` if this `Result` is [Ok] and `predicate` returns `true`.
-	/// - `false` if this `Result` is [Err], or `predicate` returns `false`
-	///
-	/// See also:
-	/// [Rust: `Result::is_ok_and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok_and)
-	bool isOkAnd(bool Function(T) predicate) => switch (this) {
-		Ok(:T v) => predicate(v),
-		Err() => false
-	};
+  /// Returns whether or not this `Result` is [Ok] and that the held value matches
+  /// the given predicate.
+  ///
+  /// Returns:
+  /// - `true` if this `Result` is [Ok] and `predicate` returns `true`.
+  /// - `false` if this `Result` is [Err], or `predicate` returns `false`
+  ///
+  /// See also:
+  /// [Rust: `Result::is_ok_and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok_and)
+  bool isOkAnd(bool Function(T) predicate) => switch (this) {
+        Ok(:T v) => predicate(v),
+        Err() => false,
+      };
 
-	/// Returns whether or not this `Result` is [Err].
-	///
-	/// See also:
-	/// [Rust: `Result::is_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err)
-	bool isErr() => !isOk();
+  /// Returns whether or not this `Result` is [Err].
+  ///
+  /// See also:
+  /// [Rust: `Result::is_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err)
+  bool isErr() => !isOk();
 
-	/// Returns whether or not this `Result` is [Err] and that the held error value
-	/// matches the given predicate.
-	///
-	/// Returns:
-	/// - `true` if this `Result` is [Err] and `predicate` returns `true`.
-	/// - `false` if this `Result` is [Ok], or `predicate` returns `false`
-	///
-	/// See also:
-	/// [Rust: `Result::is_err_and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err_and)
-	bool isErrAnd(bool Function(E) predicate) => switch (this) {
-		Ok() => false,
-		Err(:E e) => predicate(e)
-	};
+  /// Returns whether or not this `Result` is [Err] and that the held error value
+  /// matches the given predicate.
+  ///
+  /// Returns:
+  /// - `true` if this `Result` is [Err] and `predicate` returns `true`.
+  /// - `false` if this `Result` is [Ok], or `predicate` returns `false`
+  ///
+  /// See also:
+  /// [Rust: `Result::is_err_and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err_and)
+  bool isErrAnd(bool Function(E) predicate) => switch (this) {
+        Ok() => false,
+        Err(:E e) => predicate(e),
+      };
 
-	/// Returns the held value of this `Result` if it is [Ok].
-	///
-	/// **Warning**: This method is *unsafe*. A [ResultError] will be thrown when
-	/// this method is called if this `Result` is [Err].
-	///
-	/// See also:
-	/// [Rust: `Result::unwrap()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
-	T unwrap() => switch (this) {
-		Ok(:T v) => v,
-		Err() => throw ResultError(
-			'called `Result#unwrap()` on an `Err` value',
-			original: this
-		)
-	};
+  /// Returns the held value of this `Result` if it is [Ok].
+  ///
+  /// **Warning**: This method is *unsafe*. A [ResultError] will be thrown when
+  /// this method is called if this `Result` is [Err].
+  ///
+  /// See also:
+  /// [Rust: `Result::unwrap()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
+  T unwrap() => switch (this) {
+        Ok(:T v) => v,
+        Err() => throw ResultError(
+            'called `Result#unwrap()` on an `Err` value',
+            original: this,
+          )
+      };
 
-	/// Returns the held value of this `Result` if it is [Ok], or the given value
-	/// if this `Result` is [Err].
-	///
-	/// See also:
-	/// [Rust: `Result::unwrap_or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_or)
-	T unwrapOr(T orValue) => switch (this) {
-		Ok(:T v) => v,
-		Err() => orValue
-	};
+  /// Returns the held value of this `Result` if it is [Ok], or the given value
+  /// if this `Result` is [Err].
+  ///
+  /// See also:
+  /// [Rust: `Result::unwrap_or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_or)
+  T unwrapOr(T orValue) => switch (this) {
+        Ok(:T v) => v,
+        Err() => orValue,
+      };
 
-	/// Returns the held value of this `Result` if it is [Ok], or returns the
-	/// returned value from `elseFn` if this `Result` is [Err].
-	///
-	/// See also:
-	/// [Rust: `Result::unwrap_or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_or_else)
-	T unwrapOrElse(T Function() elseFn) => switch (this) {
-		Ok(:T v) => v,
-		Err() => elseFn()
-	};
+  /// Returns the held value of this `Result` if it is [Ok], or returns the
+  /// returned value from `elseFn` if this `Result` is [Err].
+  ///
+  /// See also:
+  /// [Rust: `Result::unwrap_or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_or_else)
+  T unwrapOrElse(T Function() elseFn) => switch (this) {
+        Ok(:T v) => v,
+        Err() => elseFn(),
+      };
 
-	/// Returns the held value of this `Result` if it is [Err].
-	///
-	/// **Warning**: This method is *unsafe*. A [ResultError] will be thrown when
-	/// this method is called if this `Result` is [Ok].
-	///
-	/// See also:
-	/// [Rust: `Result::unwrap_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_err)
-	E unwrapErr() => switch (this) {
-		Ok(:T v) => throw ResultError(v),
-		Err(:E e) => e
-	};
+  /// Returns the held value of this `Result` if it is [Err].
+  ///
+  /// **Warning**: This method is *unsafe*. A [ResultError] will be thrown when
+  /// this method is called if this `Result` is [Ok].
+  ///
+  /// See also:
+  /// [Rust: `Result::unwrap_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_err)
+  E unwrapErr() => switch (this) {
+        Ok(:T v) => throw ResultError(v),
+        Err(:E e) => e,
+      };
 
-	/// Returns the held value of this `Result` if it is [Ok]. Throws a [ResultError]
-	/// with the given `message` and held [Err] value if this `Result` is [Err].
-	///
-	/// See also:
-	/// [Rust: `Result::expect()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.expect)
-	T expect(String message) => switch (this) {
-		Ok(:T v) => v,
-		Err(:E e) => throw ResultError('$message: $e', isExpected: true)
-	};
+  /// Returns the held value of this `Result` if it is [Ok]. Throws a [ResultError]
+  /// with the given `message` and held [Err] value if this `Result` is [Err].
+  ///
+  /// See also:
+  /// [Rust: `Result::expect()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.expect)
+  T expect(String message) => switch (this) {
+        Ok(:T v) => v,
+        Err(:E e) => throw ResultError(
+            '$message: $e',
+            isExpected: true,
+          )
+      };
 
-	/// Returns the held value of this `Result` if it is [Err]. Throws a [ResultError]
-	/// with the given `message` and held [Ok] value if this `Result` is [Ok].
-	///
-	/// See also:
-	/// [Rust: `Result::expect_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.expect_err)
-	E expectErr(String message) => switch (this) {
-		Ok(:T v) => throw ResultError('$message: $v', isExpected: true),
-		Err(:E e) => e
-	};
+  /// Returns the held value of this `Result` if it is [Err]. Throws a [ResultError]
+  /// with the given `message` and held [Ok] value if this `Result` is [Ok].
+  ///
+  /// See also:
+  /// [Rust: `Result::expect_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.expect_err)
+  E expectErr(String message) => switch (this) {
+        Ok(:T v) => throw ResultError(
+            '$message: $v',
+            isExpected: true,
+          ),
+        Err(:E e) => e
+      };
 
-	/// Returns an [Iterable] of the held value.
-	///
-	/// Yields:
-	/// - The held `T` value if [Ok].
-	/// - Nothing if [Err].
-	///
-	/// See also:
-	/// [Rust: `Result::iter()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.iter)
-	Iterable<T> iter() sync* {
-		switch (this) {
-			case Ok(:T v): yield v;
-			case Err(): return;
-		}
-	}
+  /// Returns an [Iterable] of the held value.
+  ///
+  /// Yields:
+  /// - The held `T` value if [Ok].
+  /// - Nothing if [Err].
+  ///
+  /// See also:
+  /// [Rust: `Result::iter()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.iter)
+  Iterable<T> iter() sync* {
+    switch (this) {
+      case Ok(:T v):
+        yield v;
+      case Err():
+        return;
+    }
+  }
 
-	/// Returns a `Result` value as [Err<U, E>] if this `Result` is [Err<T, E>],
-	/// otherwise returns `other`.
-	///
-	/// See also:
-	/// [Rust: `Result::and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.and)
-	Result<U, E> and<U>(Result<U, E> other) => switch (this) {
-		Ok() => other,
-		Err(:E e) => Err(e)
-	};
+  /// Returns a `Result` value as [Err<U, E>] if this `Result` is [Err<T, E>],
+  /// otherwise returns `other`.
+  ///
+  /// See also:
+  /// [Rust: `Result::and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.and)
+  Result<U, E> and<U>(Result<U, E> other) => switch (this) {
+        Ok() => other,
+        Err(:E e) => Err(e),
+      };
 
-	/// Returns a `Result` value as [Err<U, E>] if this `Result` is [Err<T, E>],
-	/// otherwise calls `fn` with the held [Ok] value and returns the returned `Result`.
-	///
-	/// See also:
-	/// [Rust: `Result::and_then()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.and_then)
-	Result<U, E> andThen<U>(Result<U, E> Function(T) fn) => switch (this) {
-		Ok(:T v) => fn(v),
-		Err(:E e) => Err(e)
-	};
+  /// Returns a `Result` value as [Err<U, E>] if this `Result` is [Err<T, E>],
+  /// otherwise calls `fn` with the held [Ok] value and returns the returned `Result`.
+  ///
+  /// See also:
+  /// [Rust: `Result::and_then()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.and_then)
+  Result<U, E> andThen<U>(Result<U, E> Function(T) fn) => switch (this) {
+        Ok(:T v) => fn(v),
+        Err(:E e) => Err(e),
+      };
 
-	/// Returns a `Result` value as [Ok<T, F>] if this `Result` is [Ok<T, E>],
-	/// otherwise returns `other`.
-	///
-	/// See also:
-	/// [Rust: `Result::or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.or)
-	Result<T, F> or<F>(Result<T, F> other) => switch (this) {
-		Ok(:T v) => Ok(v),
-		Err() => other
-	};
+  /// Returns a `Result` value as [Ok<T, F>] if this `Result` is [Ok<T, E>],
+  /// otherwise returns `other`.
+  ///
+  /// See also:
+  /// [Rust: `Result::or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.or)
+  Result<T, F> or<F>(Result<T, F> other) => switch (this) {
+        Ok(:T v) => Ok(v),
+        Err() => other,
+      };
 
-	/// Returns a `Result` value as [Ok<T, F>] if this `Result` is [Ok<T, E>],
-	/// otherwise calls `fn` with the held [Err] value and returns the returned `Result`.
-	///
-	/// See also:
-	/// [Rust: `Result::or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.or_else)
-	Result<T, F> orElse<F>(Result<T, F> Function(E) fn) => switch (this) {
-		Ok(:T v) => Ok(v),
-		Err(:E e) => fn(e)
-	};
+  /// Returns a `Result` value as [Ok<T, F>] if this `Result` is [Ok<T, E>],
+  /// otherwise calls `fn` with the held [Err] value and returns the returned `Result`.
+  ///
+  /// See also:
+  /// [Rust: `Result::or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.or_else)
+  Result<T, F> orElse<F>(Result<T, F> Function(E) fn) => switch (this) {
+        Ok(:T v) => Ok(v),
+        Err(:E e) => fn(e),
+      };
 
-	/// Calls the provided function with the contained value if this `Result` is [Ok].
-	///
-	/// ```dart
-	/// Result<int, String> foo = Ok(1);
-	///
-	/// int bar = foo
-	///   .map((value) => value + 2)
-	///   .inspect((value) => print(value)) // prints: 3
-	///   .unwrap();
-	///
-	/// print(bar); // prints: 3
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Result::inspect()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect)
-	Result<T, E> inspect(void Function(T) fn) {
-		if (this case Ok(:T v)) {
-			fn(v);
-		}
+  /// Calls the provided function with the contained value if this `Result` is [Ok].
+  ///
+  /// ```dart
+  /// Result<int, String> foo = Ok(1);
+  ///
+  /// int bar = foo
+  ///   .map((value) => value + 2)
+  ///   .inspect((value) => print(value)) // prints: 3
+  ///   .unwrap();
+  ///
+  /// print(bar); // prints: 3
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Result::inspect()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect)
+  Result<T, E> inspect(void Function(T) fn) {
+    if (this case Ok(:T v)) {
+      fn(v);
+    }
 
-		return this;
-	}
+    return this;
+  }
 
-	/// Calls the provided function with the contained error value if this `Result`
-	/// is [Err].
-	///
-	/// ```dart
-	/// Result<int, String> foo = Err('foo');
-	///
-	/// String bar = foo
-	///   .mapErr((value) => value + 'bar')
-	///   .inspectErr((value) => print(value)) // prints: foobar
-	///   .unwrapErr();
-	///
-	/// print(bar); // prints: foobar
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Result::inspect_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect_err)
-	Result<T, E> inspectErr(void Function(E) fn) {
-		if (this case Err(:E e)) {
-			fn(e);
-		}
+  /// Calls the provided function with the contained error value if this `Result`
+  /// is [Err].
+  ///
+  /// ```dart
+  /// Result<int, String> foo = Err('foo');
+  ///
+  /// String bar = foo
+  ///   .mapErr((value) => value + 'bar')
+  ///   .inspectErr((value) => print(value)) // prints: foobar
+  ///   .unwrapErr();
+  ///
+  /// print(bar); // prints: foobar
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Result::inspect_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect_err)
+  Result<T, E> inspectErr(void Function(E) fn) {
+    if (this case Err(:E e)) {
+      fn(e);
+    }
 
-		return this;
-	}
+    return this;
+  }
 
-	/// Maps a `Result<T, E>` to a `Result<U, E>` using the given function with the
-	/// held value.
-	///
-	/// Returns:
-	/// - [Ok<U, E>] if this `Result` is [Ok<T, E>].
-	/// - [Err<U, E>] if this `Result` is [Err<T, E>].
-	///
-	/// See also:
-	/// [Rust: `Result::map()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map)
-	Result<U, E> map<U>(U Function(T) mapFn) => switch (this) {
-		Ok(:T v) => Ok(mapFn(v)),
-		Err(:E e) => Err(e)
-	};
+  /// Maps a `Result<T, E>` to a `Result<U, E>` using the given function with the
+  /// held value.
+  ///
+  /// Returns:
+  /// - [Ok<U, E>] if this `Result` is [Ok<T, E>].
+  /// - [Err<U, E>] if this `Result` is [Err<T, E>].
+  ///
+  /// See also:
+  /// [Rust: `Result::map()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map)
+  Result<U, E> map<U>(U Function(T) mapFn) => switch (this) {
+        Ok(:T v) => Ok(mapFn(v)),
+        Err(:E e) => Err(e),
+      };
 
-	/// Maps a `Result<T, E>` to a `Result<U, E>` using the given function with the
-	/// held value if the `Result<T, E>` is [Ok]. Otherwise returns the provided
-	/// `orValue` as `Ok(orValue)`.
-	///
-	/// Values passed for `orValue` are eagerly evaluated. Consider using [Result.mapOrElse()]
-	/// to provide a default that will not be evaluated unless the `Result` is [Ok].
-	///
-	/// ```dart
-	/// Result<int, String> a = Ok(1);
-	/// Result<int, String> b = Err('foo');
-	///
-	/// print(a.mapOr(5, (val) => val + 1).unwrap()); // prints: 2
-	/// print(b.mapOr(5, (val) => val + 1).unwrap()); // prints: 5
-	/// ```
-	///
-	/// **Note**: Unlike Rust's
-	/// [Result.map_or()](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or),
-	/// this method returns a `Result` value. Given that [Result.map()] returns
-	/// the mapped `Result` it just made sense for this method to do the same.
-	///
-	/// See also:
-	/// [Rust: `Result::map_or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or)
-	Result<U, E> mapOr<U>(U orValue, U Function(T) mapFn) => switch (this) {
-		Ok(:T v) => Ok(mapFn(v)),
-		Err() => Ok(orValue)
-	};
+  /// Maps a `Result<T, E>` to a `Result<U, E>` using the given function with the
+  /// held value if the `Result<T, E>` is [Ok]. Otherwise returns the provided
+  /// `orValue` as `Ok(orValue)`.
+  ///
+  /// Values passed for `orValue` are eagerly evaluated. Consider using [Result.mapOrElse()]
+  /// to provide a default that will not be evaluated unless the `Result` is [Ok].
+  ///
+  /// ```dart
+  /// Result<int, String> a = Ok(1);
+  /// Result<int, String> b = Err('foo');
+  ///
+  /// print(a.mapOr(5, (val) => val + 1).unwrap()); // prints: 2
+  /// print(b.mapOr(5, (val) => val + 1).unwrap()); // prints: 5
+  /// ```
+  ///
+  /// **Note**: Unlike Rust's
+  /// [Result.map_or()](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or),
+  /// this method returns a `Result` value. Given that [Result.map()] returns
+  /// the mapped `Result` it just made sense for this method to do the same.
+  ///
+  /// See also:
+  /// [Rust: `Result::map_or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or)
+  Result<U, E> mapOr<U>(U orValue, U Function(T) mapFn) => switch (this) {
+        Ok(:T v) => Ok(mapFn(v)),
+        Err() => Ok(orValue),
+      };
 
-	/// Maps a `Result<T, E>` to a `Result<U, E>` using the given `mapFn` function with
-	/// the held value if the `Result` is [Ok]. Otherwise returns the result of
-	/// `orFn` as `Ok(orFn())`.
-	///
-	/// `orFn` will only be evaluated if this `Result` is [Err].
-	///
-	/// ```dart
-	/// Result<int, String> a = Ok(1);
-	/// Result<int, String> b = Err('foo');
-	///
-	/// print(a.mapOrElse(() => 5, (val) => val + 1).unwrap()); // prints: 2
-	/// print(b.mapOrElse(() => 5, (val) => val + 1).unwrap()); // prints: 5
-	/// ```
-	///
-	/// **Note**: Unlike Rust's
-	/// [Result.map_or_else()](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else),
-	/// this method returns a `Result` value. Given that [Result.map()] returns
-	/// the mapped `Result` it just made sense for this method to do the same.
-	///
-	/// See also:
-	/// [Rust: `Result::map_or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else)
-	Result<U, E> mapOrElse<U>(U Function() orFn, U Function(T) mapFn) => switch (this) {
-		Ok(:T v) => Ok(mapFn(v)),
-		Err() => Ok(orFn())
-	};
+  /// Maps a `Result<T, E>` to a `Result<U, E>` using the given `mapFn` function with
+  /// the held value if the `Result` is [Ok]. Otherwise returns the result of
+  /// `orFn` as `Ok(orFn())`.
+  ///
+  /// `orFn` will only be evaluated if this `Result` is [Err].
+  ///
+  /// ```dart
+  /// Result<int, String> a = Ok(1);
+  /// Result<int, String> b = Err('foo');
+  ///
+  /// print(a.mapOrElse(() => 5, (val) => val + 1).unwrap()); // prints: 2
+  /// print(b.mapOrElse(() => 5, (val) => val + 1).unwrap()); // prints: 5
+  /// ```
+  ///
+  /// **Note**: Unlike Rust's
+  /// [Result.map_or_else()](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else),
+  /// this method returns a `Result` value. Given that [Result.map()] returns
+  /// the mapped `Result` it just made sense for this method to do the same.
+  ///
+  /// See also:
+  /// [Rust: `Result::map_or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else)
+  Result<U, E> mapOrElse<U>(U Function() orFn, U Function(T) mapFn) =>
+      switch (this) {
+        Ok(:T v) => Ok(mapFn(v)),
+        Err() => Ok(orFn()),
+      };
 
-	/// Maps a `Result<T, E>` to a `Result<T, F>` using the given function with the
-	/// held value.
-	///
-	/// Returns:
-	/// - [Ok<T, F>] if this [Result] is [Ok<T, E>].
-	/// - [Err<T, F>] if this [Result] is [Err<T, E>].
-	///
-	/// See also:
-	/// [Rust: `Result::map_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err)
-	Result<T, F> mapErr<F>(F Function(E) mapFn) => switch (this) {
-		Ok(:T v) => Ok(v),
-		Err(:E e) => Err(mapFn(e))
-	};
+  /// Maps a `Result<T, E>` to a `Result<T, F>` using the given function with the
+  /// held value.
+  ///
+  /// Returns:
+  /// - [Ok<T, F>] if this [Result] is [Ok<T, E>].
+  /// - [Err<T, F>] if this [Result] is [Err<T, E>].
+  ///
+  /// See also:
+  /// [Rust: `Result::map_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err)
+  Result<T, F> mapErr<F>(F Function(E) mapFn) => switch (this) {
+        Ok(:T v) => Ok(v),
+        Err(:E e) => Err(mapFn(e)),
+      };
 
-	/// Converts this `Result<T, E>` into an [Option<T>], discarding the held error
-	/// value if this is [Err].
-	///
-	/// Returns:
-	/// - [Some<T>] if this `Result` is [Ok<T, E>].
-	/// - [None<T>] if this `Result` is [Err<T, E>].
-	///
-	/// See also:
-	/// [Rust: `Result::ok()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.ok)
-	Option<T> ok() => switch (this) {
-		Ok(:T v) => Some(v),
-		Err() => None()
-	};
+  /// Converts this `Result<T, E>` into an [Option<T>], discarding the held error
+  /// value if this is [Err].
+  ///
+  /// Returns:
+  /// - [Some<T>] if this `Result` is [Ok<T, E>].
+  /// - [None<T>] if this `Result` is [Err<T, E>].
+  ///
+  /// See also:
+  /// [Rust: `Result::ok()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.ok)
+  Option<T> ok() => switch (this) {
+        Ok(:T v) => Some(v),
+        Err() => None(),
+      };
 
-	/// Converts this `Result<T, E>` into an [Option<E>], discarding the held value
-	/// if this is [Ok].
-	///
-	/// Returns:
-	/// - [Some<E>] if this `Result` is [Err<T, E>].
-	/// - [None<E>] if this `Result` is [Ok<T, E>].
-	///
-	/// See also:
-	/// [Rust: `Result::err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.err)
-	Option<E> err() => switch (this) {
-		Ok() => None(),
-		Err(:E e) => Some(e)
-	};
+  /// Converts this `Result<T, E>` into an [Option<E>], discarding the held value
+  /// if this is [Ok].
+  ///
+  /// Returns:
+  /// - [Some<E>] if this `Result` is [Err<T, E>].
+  /// - [None<E>] if this `Result` is [Ok<T, E>].
+  ///
+  /// See also:
+  /// [Rust: `Result::err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.err)
+  Option<E> err() => switch (this) {
+        Ok() => None(),
+        Err(:E e) => Some(e),
+      };
 }
 
 /// A type that represents the successful [Result] of something.
@@ -410,17 +419,14 @@ sealed class Result<T, E> {
 /// ```dart
 /// Result<int, String> foo = Ok(42);
 ///
-/// if (foo case Ok(value: var bar)) {
+/// if (foo case Ok(v: var bar)) {
 ///   print('Ok value: $bar');
 /// }
 /// ```
 class Ok<T, E> extends Result<T, E> {
-	final T value;
+  final T v;
 
-	const Ok(this.value);
-
-	T get v => value;
-	T get val => value;
+  const Ok(this.v);
 }
 
 /// A type that represents the failure [Result] of something.
@@ -430,106 +436,100 @@ class Ok<T, E> extends Result<T, E> {
 /// ```dart
 /// Result<int, String> foo = Err('panic!');
 ///
-/// if (foo case Err(value: var err)) {
+/// if (foo case Err(e: var err)) {
 ///   print('Error value: $err');
 /// }
 /// ```
 class Err<T, E> extends Result<T, E> {
-	final E value;
+  final E e;
 
-	const Err(this.value);
-
-	E get v => value;
-	E get val => value;
-
-	E get e => value;
-	E get error => value;
+  const Err(this.e);
 }
 
 /// Provides the `flatten()` method to [Result] type values that hold another [Result].
 extension ResultFlatten<T, E> on Result<Result<T, E>, E> {
-	/// Flattens a nested `Result` type value one level.
-	///
-	/// Returns:
-	/// - [Ok<T, E>] if this `Result` is [Ok<Result<T, E>, E>]
-	/// - [Err<T, E>] if this `Result` is [Err<Result<T, E>. E>]
-	///
-	/// See also:
-	/// [Rust: `Result::flatten()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.flatten)
-	Result<T, E> flatten() => andThen(identity);
+  /// Flattens a nested `Result` type value one level.
+  ///
+  /// Returns:
+  /// - [Ok<T, E>] if this `Result` is [Ok<Result<T, E>, E>]
+  /// - [Err<T, E>] if this `Result` is [Err<Result<T, E>. E>]
+  ///
+  /// See also:
+  /// [Rust: `Result::flatten()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.flatten)
+  Result<T, E> flatten() => andThen(identity);
 }
 
 /// Provides the `transpose()` method to [Result] type values that hold an [Option] value.
 extension ResultTranspose<T, E> on Result<Option<T>, E> {
-	/// Transposes this `Result<Option<T>, E>` into an [Option<Result<T, E>>].
-	///
-	/// Returns:
-	/// - [Some<Ok<T, E>>] if this `Result` is [Ok<Some<T>, E>].
-	/// - [None<Result<T, E>>] if this `Result` is [Ok<None<T>, E>].
-	/// - [Some<Err<T, E>>] if this `Result` is [Err<Option<T>, E>].
-	///
-	/// ```dart
-	/// Result<Option<int>, String> a = Ok(Some(1));
-	/// Option<Result<int, String>> b = Some(Ok(1));
-	///
-	/// print(a.transpose() == b); // prints: true
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Result::transpose()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.transpose)
-	Option<Result<T, E>> transpose() => switch (this) {
-		Ok(v: Some(:T v)) => Some(Ok(v)),
-		Ok(v: None()) => None(),
-		Err(:E e) => Some(Err(e))
-	};
+  /// Transposes this `Result<Option<T>, E>` into an [Option<Result<T, E>>].
+  ///
+  /// Returns:
+  /// - [Some<Ok<T, E>>] if this `Result` is [Ok<Some<T>, E>].
+  /// - [None<Result<T, E>>] if this `Result` is [Ok<None<T>, E>].
+  /// - [Some<Err<T, E>>] if this `Result` is [Err<Option<T>, E>].
+  ///
+  /// ```dart
+  /// Result<Option<int>, String> a = Ok(Some(1));
+  /// Option<Result<int, String>> b = Some(Ok(1));
+  ///
+  /// print(a.transpose() == b); // prints: true
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Result::transpose()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.transpose)
+  Option<Result<T, E>> transpose() => switch (this) {
+        Ok(v: Some(:T v)) => Some(Ok(v)),
+        Ok(v: None()) => None(),
+        Err(:E e) => Some(Err(e)),
+      };
 }
 
 /// Provides `call` functionality to [Future] values that complete with a [Result]
 /// type value.
 extension ResultFutureUnwrap<T, E> on Future<Result<T, E>> {
-	/// Allows calling a `Future<Result<T, E>>` value like a function, transforming
-	/// it into a [Future] that unwraps the returned `Result` value.
-	///
-	/// **Warning**: This is an *unsafe* operation. A [ResultError] will be thrown
-	/// if this operation is used on a [Future] returning an [Err] value when that
-	/// [Future] completes. You can take advantage of this safely via [catchResultAsync].
-	///
-	/// ```dart
-	/// Future<Result<int, String>> resultReturn() async {
-	///   return Ok(1);
-	/// }
-	///
-	/// int foo = await resultReturn()();
-	///
-	/// print(foo) // prints: 1
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Result::unwrap()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
-	Future<T> call() async => (await this).unwrap();
+  /// Allows calling a `Future<Result<T, E>>` value like a function, transforming
+  /// it into a [Future] that unwraps the returned `Result` value.
+  ///
+  /// **Warning**: This is an *unsafe* operation. A [ResultError] will be thrown
+  /// if this operation is used on a [Future] returning an [Err] value when that
+  /// [Future] completes. You can take advantage of this safely via [catchResultAsync].
+  ///
+  /// ```dart
+  /// Future<Result<int, String>> resultReturn() async {
+  ///   return Ok(1);
+  /// }
+  ///
+  /// int foo = await resultReturn()();
+  ///
+  /// print(foo) // prints: 1
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Result::unwrap()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
+  Future<T> call() async => (await this).unwrap();
 }
 
 /// Provides `call` functionality to [FutureOr] values that complete with a [Result]
 /// type value.
 extension ResultFutureOrUnwrap<T, E> on FutureOr<Result<T, E>> {
-	/// Allows calling a `FutureOr<Result<T, E>>` value like a function, transforming
-	/// it into a [Future] that unwraps the returned `Result` value.
-	///
-	/// **Warning**: This is an *unsafe* operation. A [ResultError] will be thrown
-	/// if this operation is used on a [FutureOr] containing an [Err] value when that
-	/// [FutureOr] completes. You can take advantage of this safely via [catchResultAsync].
-	///
-	/// ```dart
-	/// Future<Result<int, String>> resultReturn() {
-	///   return Ok(1);
-	/// }
-	///
-	/// int foo = await resultReturn()();
-	///
-	/// print(foo) // prints: 1
-	/// ```
-	///
-	/// See also:
-	/// [Rust: `Result::unwrap()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
-	Future<T> call() async => (await this).unwrap();
+  /// Allows calling a `FutureOr<Result<T, E>>` value like a function, transforming
+  /// it into a [Future] that unwraps the returned `Result` value.
+  ///
+  /// **Warning**: This is an *unsafe* operation. A [ResultError] will be thrown
+  /// if this operation is used on a [FutureOr] containing an [Err] value when that
+  /// [FutureOr] completes. You can take advantage of this safely via [catchResultAsync].
+  ///
+  /// ```dart
+  /// Future<Result<int, String>> resultReturn() {
+  ///   return Ok(1);
+  /// }
+  ///
+  /// int foo = await resultReturn()();
+  ///
+  /// print(foo) // prints: 1
+  /// ```
+  ///
+  /// See also:
+  /// [Rust: `Result::unwrap()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
+  Future<T> call() async => (await this).unwrap();
 }

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -2,331 +2,339 @@ import 'package:test/test.dart';
 import 'package:option_result/option_result.dart';
 
 void main() {
-	group('Option:', () {
-		test('Should provide a hashCode', () {
-			expect(Some(1).hashCode, equals(Object.hash('Some()', 1)));
-			expect(None().hashCode, equals(Object.hash('None()', None().runtimeType)));
-		});
-
-		test('Should provide a string representation', () {
-			expect(Some(1).toString(), equals('Some(1)'));
-			expect(Some('foo').toString(), equals('Some(foo)'));
-			expect(Some({'foo': 'bar'}).toString(), equals('Some({foo: bar})'));
-			expect(Some([1, 2, 3]).toString(), equals('Some([1, 2, 3])'));
-			expect(Some({1, 2, 3}).toString(), equals('Some({1, 2, 3})'));
-
-			expect(None().toString(), equals('None()'));
-		});
-
-		test('Should hold and unwrap simple values', () {
-			expect(Some('foo bar baz').unwrap(), equals('foo bar baz'));
-			expect(Some(42).unwrap(), equals(42));
-			expect(Some(false).unwrap(), equals(false));
-		});
-
-		test('Should hold and unwrap complex values', () {
-			expect(Some({'foo': 'bar', 'baz': 42}).unwrap(), equals({'foo': 'bar', 'baz': 42}));
-			expect(Some(['foo', 'bar', 'baz']).unwrap(), equals(['foo', 'bar', 'baz']));
-		});
-
-		test('Should unwrap values via shorthand getters', () {
-			Option<int> foo = Some(1);
-
-			if (foo case Some(:int v)) { expect(v, equals(1)); }
-			if (foo case Some(:int val)) { expect(val, equals(1)); }
-		});
-
-		test('Should create expected Options via Option.from()', () {
-			expect(Option.from('foo'), equals(Some('foo')));
-			expect(Option<int>.from(null), equals(None<int>()));
-		});
-
-		test('Should equate equatable Options', () {
-			expect(Some('foo') == Some('foo'), equals(true));
-			expect(None() == None(), equals(true));
-
-			Map<String, dynamic> foo = {'foo': 'bar', 'baz': 42};
-
-			// They share the same reference to foo
-			expect(Some(foo) == Some(foo), equals(true));
-
-			// Different types, but equatable values
-			expect(Some<int>(1) == Some<num>(1), equals(true));
-			expect(Some<num>(1) == Some<double>(1), equals(true));
-
-			// None() is always equal to None(), regardless of type
-			// ignore: unrelated_type_equality_checks
-			expect(None<int>() == None<String>(), equals(true));
-		});
-
-		test('Should throw OptionError when unwrapping None()', () {
-			expect(() => None().unwrap(), throwsA(TypeMatcher<OptionError>()));
-		});
-
-		test('Should return expected values from Option#isSome()', () {
-			expect(Some(null).isSome(), equals(true));
-			expect(None().isSome(), equals(false));
-		});
-
-		test('Should return expected values from Option#isSomeAnd()', () {
-			expect(Some(1).isSomeAnd((value) => value == 1), equals(true));
-			expect(Some(1).isSomeAnd((value) => value >= 2), equals(false));
-			expect(None().isSomeAnd((_) => true), equals(false));
-		});
-
-		test('Should return expected values from Option#isNone()', () {
-			expect(Some(null).isNone(), equals(false));
-			expect(None().isNone(), equals(true));
-		});
-
-		test('Should return expected values from Option#unwrapOr()', () {
-			expect(Some(1).unwrapOr(2), equals(1));
-			expect(None().unwrapOr(2), equals(2));
-		});
-
-		test('Should return expected values from Option#unwrapOrElse()', () {
-			expect(Some(1).unwrapOrElse(() => 2), equals(1));
-			expect(None().unwrapOrElse(() => 2), equals(2));
-		});
-
-		test('Should return expected values from Option#expect()', () {
-			expect(Some(1).expect('should be Some()'), equals(1));
-			expect(() => None().expect('Should be Some()'), throwsA(TypeMatcher<OptionError>()));
-		});
-
-		test('Should iterate over the held value via Option#iter()', () {
-			Option<int> foo = Some(1);
-			Option<int> bar = None();
-
-			for (int value in foo.iter()) {
-				expect(value, equals(1));
-			}
-
-			bool called = false;
-			void call() => called = true;
+  group('Option:', () {
+    test('Should provide a hashCode', () {
+      expect(Some(1).hashCode, equals(Object.hash('Some()', 1)));
+      expect(
+          None().hashCode, equals(Object.hash('None()', None().runtimeType)));
+    });
+
+    test('Should provide a string representation', () {
+      expect(Some(1).toString(), equals('Some(1)'));
+      expect(Some('foo').toString(), equals('Some(foo)'));
+      expect(Some({'foo': 'bar'}).toString(), equals('Some({foo: bar})'));
+      expect(Some([1, 2, 3]).toString(), equals('Some([1, 2, 3])'));
+      expect(Some({1, 2, 3}).toString(), equals('Some({1, 2, 3})'));
+
+      expect(None().toString(), equals('None()'));
+    });
+
+    test('Should hold and unwrap simple values', () {
+      expect(Some('foo bar baz').unwrap(), equals('foo bar baz'));
+      expect(Some(42).unwrap(), equals(42));
+      expect(Some(false).unwrap(), equals(false));
+    });
+
+    test('Should hold and unwrap complex values', () {
+      expect(Some({'foo': 'bar', 'baz': 42}).unwrap(),
+          equals({'foo': 'bar', 'baz': 42}));
+      expect(
+          Some(['foo', 'bar', 'baz']).unwrap(), equals(['foo', 'bar', 'baz']));
+    });
+
+    test('Should unwrap values via shorthand getters', () {
+      Option<int> foo = Some(1);
+
+      if (foo case Some(:int v)) {
+        expect(v, equals(1));
+      }
+    });
+
+    test('Should create expected Options via Option.from()', () {
+      expect(Option.from('foo'), equals(Some('foo')));
+      expect(Option<int>.from(null), equals(None<int>()));
+    });
+
+    test('Should equate equatable Options', () {
+      expect(Some('foo') == Some('foo'), equals(true));
+      expect(None() == None(), equals(true));
+
+      Map<String, dynamic> foo = {'foo': 'bar', 'baz': 42};
+
+      // They share the same reference to foo
+      expect(Some(foo) == Some(foo), equals(true));
+
+      // Different types, but equatable values
+      expect(Some<int>(1) == Some<num>(1), equals(true));
+      expect(Some<num>(1) == Some<double>(1), equals(true));
+
+      // None() is always equal to None(), regardless of type
+      // ignore: unrelated_type_equality_checks
+      expect(None<int>() == None<String>(), equals(true));
+    });
+
+    test('Should throw OptionError when unwrapping None()', () {
+      expect(() => None().unwrap(), throwsA(TypeMatcher<OptionError>()));
+    });
+
+    test('Should return expected values from Option#isSome()', () {
+      expect(Some(null).isSome(), equals(true));
+      expect(None().isSome(), equals(false));
+    });
+
+    test('Should return expected values from Option#isSomeAnd()', () {
+      expect(Some(1).isSomeAnd((value) => value == 1), equals(true));
+      expect(Some(1).isSomeAnd((value) => value >= 2), equals(false));
+      expect(None().isSomeAnd((_) => true), equals(false));
+    });
+
+    test('Should return expected values from Option#isNone()', () {
+      expect(Some(null).isNone(), equals(false));
+      expect(None().isNone(), equals(true));
+    });
+
+    test('Should return expected values from Option#unwrapOr()', () {
+      expect(Some(1).unwrapOr(2), equals(1));
+      expect(None().unwrapOr(2), equals(2));
+    });
+
+    test('Should return expected values from Option#unwrapOrElse()', () {
+      expect(Some(1).unwrapOrElse(() => 2), equals(1));
+      expect(None().unwrapOrElse(() => 2), equals(2));
+    });
+
+    test('Should return expected values from Option#expect()', () {
+      expect(Some(1).expect('should be Some()'), equals(1));
+      expect(() => None().expect('Should be Some()'),
+          throwsA(TypeMatcher<OptionError>()));
+    });
+
+    test('Should iterate over the held value via Option#iter()', () {
+      Option<int> foo = Some(1);
+      Option<int> bar = None();
+
+      for (int value in foo.iter()) {
+        expect(value, equals(1));
+      }
 
-			// The call() function should not run since there's nothing to iterate
-			// over in a None() value
-			for (int _ in bar.iter()) {
-				call();
-			}
+      bool called = false;
+      void call() => called = true;
 
-			expect(called, equals(false));
-		});
+      // The call() function should not run since there's nothing to iterate
+      // over in a None() value
+      for (int _ in bar.iter()) {
+        call();
+      }
 
-		test('Should return expected values from Option#and()', () {
-			Option<int> foo = Some(1);
-			Option<int> bar = None();
+      expect(called, equals(false));
+    });
 
-			expect(foo.and(Some(2)), equals(Some(2)));
-			expect(bar.and(Some(2)), equals(None<int>()));
+    test('Should return expected values from Option#and()', () {
+      Option<int> foo = Some(1);
+      Option<int> bar = None();
 
-			expect(foo.and(Some('foo')), equals(Some('foo')));
-			expect(bar.and(Some('foo')), equals(None<String>()));
-		});
+      expect(foo.and(Some(2)), equals(Some(2)));
+      expect(bar.and(Some(2)), equals(None<int>()));
 
-		test('Should return expected values from Option#andThen()', () {
-			Option<int> foo = Some(1);
-			Option<int> bar = None();
+      expect(foo.and(Some('foo')), equals(Some('foo')));
+      expect(bar.and(Some('foo')), equals(None<String>()));
+    });
 
-			expect(foo.andThen((value) => Some(value * 2)), equals(Some(2)));
-			expect(bar.andThen((value) => Some(value * 2)), equals(None<int>()));
+    test('Should return expected values from Option#andThen()', () {
+      Option<int> foo = Some(1);
+      Option<int> bar = None();
 
-			expect(foo.andThen((value) => Some(value.toString())), equals(Some('1')));
-			expect(bar.andThen((value) => Some(value.toString())), equals(None<String>()));
-		});
+      expect(foo.andThen((value) => Some(value * 2)), equals(Some(2)));
+      expect(bar.andThen((value) => Some(value * 2)), equals(None<int>()));
 
-		test('Should return expected values from Option#or()', () {
-			Option<int> foo = None();
-			Option<int> bar = Some(1);
-			Option<int> baz = None();
+      expect(foo.andThen((value) => Some(value.toString())), equals(Some('1')));
+      expect(bar.andThen((value) => Some(value.toString())),
+          equals(None<String>()));
+    });
 
-			expect(foo.or(bar), equals(Some(1)));
-			expect(bar.or(Some(2)), equals(Some(1)));
-			expect(foo.or(baz), equals(None<int>()));
-		});
+    test('Should return expected values from Option#or()', () {
+      Option<int> foo = None();
+      Option<int> bar = Some(1);
+      Option<int> baz = None();
 
-		test('Should return expected values from Option#orElse()', () {
-			Option<int> foo = None();
-			Option<int> bar = Some(1);
-			Option<int> baz = None();
+      expect(foo.or(bar), equals(Some(1)));
+      expect(bar.or(Some(2)), equals(Some(1)));
+      expect(foo.or(baz), equals(None<int>()));
+    });
 
-			expect(foo.orElse(() => Some(2)), equals(Some(2)));
-			expect(bar.orElse(() => Some(2)), equals(Some(1)));
-			expect(baz.orElse(() => None()), equals(None<int>()));
-		});
+    test('Should return expected values from Option#orElse()', () {
+      Option<int> foo = None();
+      Option<int> bar = Some(1);
+      Option<int> baz = None();
 
-		test('Should return expected values from Option#xor()', () {
-			Option<int> a = Some(1);
-			Option<int> b = None();
-			Option<int> c = Some(2);
+      expect(foo.orElse(() => Some(2)), equals(Some(2)));
+      expect(bar.orElse(() => Some(2)), equals(Some(1)));
+      expect(baz.orElse(() => None()), equals(None<int>()));
+    });
 
-			expect(a.xor(b), equals(Some(1)));
-			expect(b.xor(c), equals(Some(2)));
-			expect(a.xor(c), equals(None<int>()));
-			expect(b.xor(b), equals(None<int>()));
-		});
+    test('Should return expected values from Option#xor()', () {
+      Option<int> a = Some(1);
+      Option<int> b = None();
+      Option<int> c = Some(2);
 
-		test('Should execute the given function and return self as expected in Option#inspect()', () {
-			bool called = false;
+      expect(a.xor(b), equals(Some(1)));
+      expect(b.xor(c), equals(Some(2)));
+      expect(a.xor(c), equals(None<int>()));
+      expect(b.xor(b), equals(None<int>()));
+    });
 
-			void inspectFn(int value) {
-				called = true;
-			}
+    test(
+        'Should execute the given function and return self as expected in Option#inspect()',
+        () {
+      bool called = false;
 
-			Option<int> foo = Some(1);
+      void inspectFn(int value) {
+        called = true;
+      }
 
-			int bar = foo.inspect(inspectFn).unwrap();
+      Option<int> foo = Some(1);
 
-			expect(bar, equals(1));
-			expect(called, equals(true));
-		});
+      int bar = foo.inspect(inspectFn).unwrap();
 
-		test('Should return expected values from Option#filter()', () {
-			Option<int> foo = Some(5);
+      expect(bar, equals(1));
+      expect(called, equals(true));
+    });
 
-			expect(foo.where((value) => value < 10), equals(Some(5)));
-			expect(foo.where((value) => value > 6), equals(None<int>()));
+    test('Should return expected values from Option#filter()', () {
+      Option<int> foo = Some(5);
 
-			Option<int> bar = None();
+      expect(foo.where((value) => value < 10), equals(Some(5)));
+      expect(foo.where((value) => value > 6), equals(None<int>()));
 
-			expect(bar.where((value) => value < 10), equals(None<int>()));
-		});
+      Option<int> bar = None();
 
-		test('Should return expected values from Option#map()', () {
-			Option<int> bar = None();
+      expect(bar.where((value) => value < 10), equals(None<int>()));
+    });
 
-			expect(bar.map((value) => value + 1), equals(None<int>()));
+    test('Should return expected values from Option#map()', () {
+      Option<int> bar = None();
 
-			Option<int> foo = Some(5);
+      expect(bar.map((value) => value + 1), equals(None<int>()));
 
-			expect(foo.map((value) => value * 10), equals(Some(50)));
-			expect(foo.map((value) => value.toString()), equals(Some('5')));
+      Option<int> foo = Some(5);
 
-			expect(foo.map((value) => [value]), equals(TypeMatcher<Some<List<int>>>()));
+      expect(foo.map((value) => value * 10), equals(Some(50)));
+      expect(foo.map((value) => value.toString()), equals(Some('5')));
 
-			// Check the wrapped List directly because two Options holding
-			// different references to visibly identical lists aren't equatable
-			expect(foo.map((value) => [value]).unwrap(), equals([5]));
+      expect(
+          foo.map((value) => [value]), equals(TypeMatcher<Some<List<int>>>()));
 
-		});
+      // Check the wrapped List directly because two Options holding
+      // different references to visibly identical lists aren't equatable
+      expect(foo.map((value) => [value]).unwrap(), equals([5]));
+    });
 
-		test('Should return expected values from Option#mapOr()', () {
-			Option<int> a = Some(1);
-			Option<int> b = None();
+    test('Should return expected values from Option#mapOr()', () {
+      Option<int> a = Some(1);
+      Option<int> b = None();
 
-			expect(a.mapOr(5, (val) => val + 1), equals(Some(2)));
-			expect(b.mapOr(5, (val) => val + 1), equals(Some(5)));
-		});
+      expect(a.mapOr(5, (val) => val + 1), equals(Some(2)));
+      expect(b.mapOr(5, (val) => val + 1), equals(Some(5)));
+    });
 
-		test('Should return expected values from Option#mapOrElse()', () {
-			Option<int> a = Some(1);
-			Option<int> b = None();
+    test('Should return expected values from Option#mapOrElse()', () {
+      Option<int> a = Some(1);
+      Option<int> b = None();
 
-			expect(a.mapOrElse(() => 5, (val) => val + 1), equals(Some(2)));
-			expect(b.mapOrElse(() => 5, (val) => val + 1), equals(Some(5)));
-		});
+      expect(a.mapOrElse(() => 5, (val) => val + 1), equals(Some(2)));
+      expect(b.mapOrElse(() => 5, (val) => val + 1), equals(Some(5)));
+    });
 
-		test('Should return expected values from Option#zip()', () {
-			Option<(int, String)> zipped = Some(1).zip(Some('foo'));
+    test('Should return expected values from Option#zip()', () {
+      Option<(int, String)> zipped = Some(1).zip(Some('foo'));
 
-			expect(zipped, equals(Some((1, 'foo'))));
-			expect(Some(1).zip(None<int>()), equals(None<(int, int)>()));
-		});
+      expect(zipped, equals(Some((1, 'foo'))));
+      expect(Some(1).zip(None<int>()), equals(None<(int, int)>()));
+    });
 
-		test('Should return expected values from Option#zipWith()', () {
-			Option<int> x = Some(1);
-			Option<int> y = Some(2);
-			Option<int> z = None();
+    test('Should return expected values from Option#zipWith()', () {
+      Option<int> x = Some(1);
+      Option<int> y = Some(2);
+      Option<int> z = None();
 
-			expect(x.zipWith(y, Point.new), equals(Some(Point(1, 2))));
-			expect(x.zipWith(z, Point.new), equals(None<Point>()));
-		});
+      expect(x.zipWith(y, Point.new), equals(Some(Point(1, 2))));
+      expect(x.zipWith(z, Point.new), equals(None<Point>()));
+    });
 
-		test('Should return expected values from Option#unzip()', () {
-			Option<(int, String)> zipped = Some((1, 'foo'));
+    test('Should return expected values from Option#unzip()', () {
+      Option<(int, String)> zipped = Some((1, 'foo'));
 
-			expect(zipped.unzip(), equals((Some(1), Some('foo'))));
-			expect(None<(int, int)>().unzip(), equals((None<int>(), None<int>())));
+      expect(zipped.unzip(), equals((Some(1), Some('foo'))));
+      expect(None<(int, int)>().unzip(), equals((None<int>(), None<int>())));
 
-			// Test implicit and explicit typing on unzip()
-			Option<(int, int)> foo = None();
-			(Option<int>, Option<int>) bar = foo.unzip();
-			var baz = foo.unzip();
+      // Test implicit and explicit typing on unzip()
+      Option<(int, int)> foo = None();
+      (Option<int>, Option<int>) bar = foo.unzip();
+      var baz = foo.unzip();
 
-			expect(bar, equals((None<int>(), None<int>())));
-			expect(baz, equals((None<int>(), None<int>())));
-		});
+      expect(bar, equals((None<int>(), None<int>())));
+      expect(baz, equals((None<int>(), None<int>())));
+    });
 
-		test('Should return expected values from Option#flatten()', () {
-			Option<Option<Option<Option<int>>>> foo = Some(Some(Some(Some(1))));
+    test('Should return expected values from Option#flatten()', () {
+      Option<Option<Option<Option<int>>>> foo = Some(Some(Some(Some(1))));
 
-			// Option.from() here because it won't equate Some<Some<T>> to Option<Option<T>>
-			// but Option<Option<T>> compares fine. I assumed it was from the runtimeType
-			// comparison in == but removing that still doesn't allow equals() to consider
-			// the values the same here despite that fixing == for these cases.
-			expect(foo.flatten(), equals(Option.from(Option.from(Option.from(1)))));
-			expect(foo.flatten().flatten(), equals(Option.from(Option.from(1))));
-			expect(foo.flatten().flatten().flatten(), equals(Option.from(1)));
+      // Option.from() here because it won't equate Some<Some<T>> to Option<Option<T>>
+      // but Option<Option<T>> compares fine. I assumed it was from the runtimeType
+      // comparison in == but removing that still doesn't allow equals() to consider
+      // the values the same here despite that fixing == for these cases.
+      expect(foo.flatten(), equals(Option.from(Option.from(Option.from(1)))));
+      expect(foo.flatten().flatten(), equals(Option.from(Option.from(1))));
+      expect(foo.flatten().flatten().flatten(), equals(Option.from(1)));
 
-			// 4 flatten()s won't compile because it's no longer Option<Option<int>> after 3
-			// expect(foo.flatten().flatten().flatten().flatten(), equals(Some(1)));
+      // 4 flatten()s won't compile because it's no longer Option<Option<int>> after 3
+      // expect(foo.flatten().flatten().flatten().flatten(), equals(Some(1)));
 
-			Option<Option<int>> bar = None();
+      Option<Option<int>> bar = None();
 
-			expect(bar.flatten(), equals(None<int>()));
-		});
+      expect(bar.flatten(), equals(None<int>()));
+    });
 
-		test('Should return expected values from Option#okOr()', () {
-			Option<int> foo = Some(1);
-			Option<int> bar = None();
+    test('Should return expected values from Option#okOr()', () {
+      Option<int> foo = Some(1);
+      Option<int> bar = None();
 
-			expect(foo.okOr('foo'), equals(Ok<int, String>(1)));
-			expect(bar.okOr('bar'), equals(Err<int, String>('bar')));
-		});
+      expect(foo.okOr('foo'), equals(Ok<int, String>(1)));
+      expect(bar.okOr('bar'), equals(Err<int, String>('bar')));
+    });
 
-		test('Should return expected values from Option#okOrElse()', () {
-			Option<int> foo = Some(1);
-			Option<int> bar = None();
+    test('Should return expected values from Option#okOrElse()', () {
+      Option<int> foo = Some(1);
+      Option<int> bar = None();
 
-			expect(foo.okOrElse(() => 'foo'), equals(Ok<int, String>(1)));
-			expect(bar.okOrElse(() => 'bar'), equals(Err<int, String>('bar')));
-		});
+      expect(foo.okOrElse(() => 'foo'), equals(Ok<int, String>(1)));
+      expect(bar.okOrElse(() => 'bar'), equals(Err<int, String>('bar')));
+    });
 
-		test('Should return expected values from Option#transpose()', () {
-			Option<Result<int, String>> foo = Some(Ok(1));
-			Option<Result<int, String>> bar = Some(Err('bar'));
-			Option<Result<int, String>> baz = None();
+    test('Should return expected values from Option#transpose()', () {
+      Option<Result<int, String>> foo = Some(Ok(1));
+      Option<Result<int, String>> bar = Some(Err('bar'));
+      Option<Result<int, String>> baz = None();
 
-			expect(foo.transpose(), equals(Ok<Option<int>, String>(Some(1))));
-			expect(bar.transpose(), equals(Err<Option<int>, String>('bar')));
-			expect(baz.transpose(), equals(Ok<Option<int>, String>(None())));
-		});
-	});
+      expect(foo.transpose(), equals(Ok<Option<int>, String>(Some(1))));
+      expect(bar.transpose(), equals(Err<Option<int>, String>('bar')));
+      expect(baz.transpose(), equals(Ok<Option<int>, String>(None())));
+    });
+  });
 
-	group('OptionError:', () {
-		test('Should return expected values from ResultError#toString()', () {
-			OptionError foo = OptionError(null);
-			OptionError bar = OptionError('bar');
+  group('OptionError:', () {
+    test('Should return expected values from ResultError#toString()', () {
+      OptionError foo = OptionError(null);
+      OptionError bar = OptionError('bar');
 
-			expect(foo.toString(), equals('OptionError'));
-			expect(bar.toString(), equals('OptionError: bar'));
-		});
-	});
+      expect(foo.toString(), equals('OptionError'));
+      expect(bar.toString(), equals('OptionError: bar'));
+    });
+  });
 }
 
 class Point {
-	int x;
-	int y;
+  int x;
+  int y;
 
-	Point(this.x, this.y);
+  Point(this.x, this.y);
 
-	@override
-	operator ==(Object other) => switch (other) {
-		Point(x: int otherX, y: int otherY) => x == otherX && y == otherY,
-		_ => false
-	};
+  @override
+  operator ==(Object other) => switch (other) {
+        Point(x: int otherX, y: int otherY) => x == otherX && y == otherY,
+        _ => false
+      };
 
-	@override
-	int get hashCode => Object.hash(x, y);
+  @override
+  int get hashCode => Object.hash(x, y);
 }

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -1,334 +1,363 @@
 import 'package:test/test.dart';
 import 'package:option_result/option_result.dart';
 
-void main () {
-	group('Result:', () {
-		test('Should provide a hashCode', () {
-			expect(Ok(1).hashCode, equals(Object.hash('Ok()', 1)));
-			expect(Err(1).hashCode, equals(Object.hash('Err()', 1)));
-		});
-
-		test('Should provide a string representation', () {
-			expect(Ok(1).toString(), equals('Ok(1)'));
-			expect(Ok('foo').toString(), equals('Ok(foo)'));
-			expect(Ok({'foo': 'bar'}).toString(), equals('Ok({foo: bar})'));
-			expect(Ok([1, 2, 3]).toString(), equals('Ok([1, 2, 3])'));
-			expect(Ok({1, 2, 3}).toString(), equals('Ok({1, 2, 3})'));
-
-			expect(Err(1).toString(), equals('Err(1)'));
-			expect(Err('foo').toString(), equals('Err(foo)'));
-			expect(Err({'foo': 'bar'}).toString(), equals('Err({foo: bar})'));
-			expect(Err([1, 2, 3]).toString(), equals('Err([1, 2, 3])'));
-			expect(Err({1, 2, 3}).toString(), equals('Err({1, 2, 3})'));
-		});
-
-		test('Should hold and unwrap simple Ok values', () {
-			expect(Ok('foo bar baz').unwrap(), equals('foo bar baz'));
-			expect(Ok(42).unwrap(), equals(42));
-			expect(Ok(false).unwrap(), equals(false));
-		});
-
-		test('Should hold and unwrap simple Err values', () {
-			expect(Err('foo bar baz').unwrapErr(), equals('foo bar baz'));
-			expect(Err(42).unwrapErr(), equals(42));
-			expect(Err(false).unwrapErr(), equals(false));
-		});
-
-		test('Should hold and unwrap complex Ok values', () {
-			expect(Ok({'foo': 'bar', 'baz': 42}).unwrap(), equals({'foo': 'bar', 'baz': 42}));
-			expect(Ok(['foo', 42, true]).unwrap(), equals(['foo', 42, true]));
-		});
-
-		test('Should hold and unwrap complex Err values', () {
-			expect(Err({'foo': 'bar', 'baz': 42}).unwrapErr(), equals({'foo': 'bar', 'baz': 42}));
-			expect(Err(['foo', 42, true]).unwrapErr(), equals(['foo', 42, true]));
-		});
-
-		test('Should unwrap values via shorthand getters', () {
-			Result<int, String> foo = Ok(1);
-			Result<int, String> bar = Err('bar');
-
-			if (foo case Ok(:int v)) { expect(v, equals(1)); }
-			if (foo case Ok(:int val)) { expect(val, equals(1)); }
-			if (bar case Err(:String v)) { expect(v, equals('bar')); }
-			if (bar case Err(:String val)) { expect(val, equals('bar')); }
-			if (bar case Err(:String e)) { expect(e, equals('bar')); }
-			if (bar case Err(:String error)) { expect(error, equals('bar')); }
-		});
-
-		test('Should create expected Results via Result.from()', () {
-			expect(Result.from('foo', 'err'), equals(Ok<String, String>('foo')));
-			expect(Result<String, String>.from(null, 'err'), equals(Err<String, String>('err')));
-		});
-
-		test('Should equate equatable Results', () {
-			expect(Ok('foo') == Ok('foo'), equals(true));
-			expect(Err('foo') == Err('foo'), equals(true));
-
-			Map<String, dynamic> foo = {'foo': 'bar', 'baz': 42};
-			expect(Ok(foo) == Ok(foo), equals(true));
-
-			Result<int, String> bar = Ok(1);
-			Result<int, String> baz = Ok(1);
-
-			expect(bar == baz, equals(true));
-
-			baz = Ok(2);
-
-			expect(bar == baz, equals(false));
-
-			// Irrelevant types are elided (E for Ok, T for Err), only value matters
-
-			// ignore: unrelated_type_equality_checks
-			expect(Ok<int, String>(1) == Ok<int, int>(1), equals(true));
-			// ignore: unrelated_type_equality_checks
-			expect(Err<int, String>('foo') == Err<bool, String>('foo'), equals(true));
-		});
-
-		test('Should throw ResultError when unwrapping Err()', () {
-			expect(() => Err('foo bar baz').unwrap(), throwsA(TypeMatcher<ResultError>()));
-		});
-
-		test('Should throw ResultError with unwrapErr() on Ok()', () {
-			expect(() => Ok('foo bar baz').unwrapErr(), throwsA(TypeMatcher<ResultError>()));
-		});
-
-		test('Should return expected values from Result#isOk()', () {
-			expect(Ok(null).isOk(), equals(true));
-			expect(Err(null).isOk(), equals(false));
-		});
-
-		test('Should return expected values from Result#isOkAnd()', () {
-			expect(Ok(1).isOkAnd((value) => value == 1), equals(true));
-			expect(Ok(1).isOkAnd((value) => value >= 2), equals(false));
-			expect(Err(1).isOkAnd((_) => true), equals(false));
-		});
-
-		test('Should return expected values from Result#isErr()', () {
-			expect(Ok(null).isErr(), equals(false));
-			expect(Err(null).isErr(), equals(true));
-		});
+void main() {
+  group('Result:', () {
+    test('Should provide a hashCode', () {
+      expect(Ok(1).hashCode, equals(Object.hash('Ok()', 1)));
+      expect(Err(1).hashCode, equals(Object.hash('Err()', 1)));
+    });
+
+    test('Should provide a string representation', () {
+      expect(Ok(1).toString(), equals('Ok(1)'));
+      expect(Ok('foo').toString(), equals('Ok(foo)'));
+      expect(Ok({'foo': 'bar'}).toString(), equals('Ok({foo: bar})'));
+      expect(Ok([1, 2, 3]).toString(), equals('Ok([1, 2, 3])'));
+      expect(Ok({1, 2, 3}).toString(), equals('Ok({1, 2, 3})'));
+
+      expect(Err(1).toString(), equals('Err(1)'));
+      expect(Err('foo').toString(), equals('Err(foo)'));
+      expect(Err({'foo': 'bar'}).toString(), equals('Err({foo: bar})'));
+      expect(Err([1, 2, 3]).toString(), equals('Err([1, 2, 3])'));
+      expect(Err({1, 2, 3}).toString(), equals('Err({1, 2, 3})'));
+    });
+
+    test('Should hold and unwrap simple Ok values', () {
+      expect(Ok('foo bar baz').unwrap(), equals('foo bar baz'));
+      expect(Ok(42).unwrap(), equals(42));
+      expect(Ok(false).unwrap(), equals(false));
+    });
+
+    test('Should hold and unwrap simple Err values', () {
+      expect(Err('foo bar baz').unwrapErr(), equals('foo bar baz'));
+      expect(Err(42).unwrapErr(), equals(42));
+      expect(Err(false).unwrapErr(), equals(false));
+    });
+
+    test('Should hold and unwrap complex Ok values', () {
+      expect(Ok({'foo': 'bar', 'baz': 42}).unwrap(),
+          equals({'foo': 'bar', 'baz': 42}));
+      expect(Ok(['foo', 42, true]).unwrap(), equals(['foo', 42, true]));
+    });
+
+    test('Should hold and unwrap complex Err values', () {
+      expect(Err({'foo': 'bar', 'baz': 42}).unwrapErr(),
+          equals({'foo': 'bar', 'baz': 42}));
+      expect(Err(['foo', 42, true]).unwrapErr(), equals(['foo', 42, true]));
+    });
+
+    test('Should unwrap values via shorthand getters', () {
+      Result<int, String> foo = Ok(1);
+      Result<int, String> bar = Err('bar');
+
+      if (foo case Ok(v: int v)) {
+        expect(v, equals(1));
+      }
+      if (bar case Err(:String e)) {
+        expect(e, equals('bar'));
+      }
+    });
+
+    test('Should create expected Results via Result.from()', () {
+      expect(Result.from('foo', 'err'), equals(Ok<String, String>('foo')));
+      expect(Result<String, String>.from(null, 'err'),
+          equals(Err<String, String>('err')));
+    });
+
+    test('Should equate equatable Results', () {
+      expect(Ok('foo') == Ok('foo'), equals(true));
+      expect(Err('foo') == Err('foo'), equals(true));
+
+      Map<String, dynamic> foo = {'foo': 'bar', 'baz': 42};
+      expect(Ok(foo) == Ok(foo), equals(true));
+
+      Result<int, String> bar = Ok(1);
+      Result<int, String> baz = Ok(1);
+
+      expect(bar == baz, equals(true));
+
+      baz = Ok(2);
+
+      expect(bar == baz, equals(false));
+
+      // Irrelevant types are elided (E for Ok, T for Err), only value matters
+
+      // ignore: unrelated_type_equality_checks
+      expect(Ok<int, String>(1) == Ok<int, int>(1), equals(true));
+      // ignore: unrelated_type_equality_checks
+      expect(Err<int, String>('foo') == Err<bool, String>('foo'), equals(true));
+    });
+
+    test('Should throw ResultError when unwrapping Err()', () {
+      expect(() => Err('foo bar baz').unwrap(),
+          throwsA(TypeMatcher<ResultError>()));
+    });
+
+    test('Should throw ResultError with unwrapErr() on Ok()', () {
+      expect(() => Ok('foo bar baz').unwrapErr(),
+          throwsA(TypeMatcher<ResultError>()));
+    });
+
+    test('Should return expected values from Result#isOk()', () {
+      expect(Ok(null).isOk(), equals(true));
+      expect(Err(null).isOk(), equals(false));
+    });
+
+    test('Should return expected values from Result#isOkAnd()', () {
+      expect(Ok(1).isOkAnd((value) => value == 1), equals(true));
+      expect(Ok(1).isOkAnd((value) => value >= 2), equals(false));
+      expect(Err(1).isOkAnd((_) => true), equals(false));
+    });
+
+    test('Should return expected values from Result#isErr()', () {
+      expect(Ok(null).isErr(), equals(false));
+      expect(Err(null).isErr(), equals(true));
+    });
+
+    test('Should return expected values from Result#isErrAnd()', () {
+      expect(Err(1).isErrAnd((value) => value == 1), equals(true));
+      expect(Err(1).isErrAnd((value) => value >= 2), equals(false));
+      expect(Ok(1).isErrAnd((_) => true), equals(false));
+    });
+
+    test('Should return expected values from Result#unwrapOr()', () {
+      expect(Ok(1).unwrapOr(2), equals(1));
+      expect(Err(1).unwrapOr(2), equals(2));
+    });
+
+    test('Should return expected values from Result#unwrapOrElse()', () {
+      expect(Ok(1).unwrapOrElse(() => 2), equals(1));
+      expect(Err(1).unwrapOrElse(() => 2), equals(2));
+    });
+
+    test('Should return expected values from Result#expect()', () {
+      expect(Ok(1).expect('should be Ok()'), equals(1));
+      expect(() => Err('foo').expect('Should be Ok()'),
+          throwsA(TypeMatcher<ResultError>()));
+    });
+
+    test('Should return expected values from Result#expectErr()', () {
+      expect(Err(1).expectErr('should be Err()'), equals(1));
+      expect(() => Ok('foo').expectErr('Should be Err()'),
+          throwsA(TypeMatcher<ResultError>()));
+    });
+
+    test('Should iterate over the held value via Result#iter()', () {
+      Result<int, String> foo = Ok(1);
+      Result<int, String> bar = Err('foo');
+
+      for (int value in foo.iter()) {
+        expect(value, equals(1));
+      }
+
+      bool called = false;
+      void call() => called = true;
+
+      // The call() function should not run since there's nothing to iterate
+      // over in an Err() value
+      for (int _ in bar.iter()) {
+        call();
+      }
+
+      expect(called, equals(false));
+    });
 
-		test('Should return expected values from Result#isErrAnd()', () {
-			expect(Err(1).isErrAnd((value) => value == 1), equals(true));
-			expect(Err(1).isErrAnd((value) => value >= 2), equals(false));
-			expect(Ok(1).isErrAnd((_) => true), equals(false));
-		});
+    test('Should return expected values from Result#and()', () {
+      Result<int, String> foo = Ok(1);
+      Result<int, String> bar = Err('bar');
 
-		test('Should return expected values from Result#unwrapOr()', () {
-			expect(Ok(1).unwrapOr(2), equals(1));
-			expect(Err(1).unwrapOr(2), equals(2));
-		});
-
-		test('Should return expected values from Result#unwrapOrElse()', () {
-			expect(Ok(1).unwrapOrElse(() => 2), equals(1));
-			expect(Err(1).unwrapOrElse(() => 2), equals(2));
-		});
-
-		test('Should return expected values from Result#expect()', () {
-			expect(Ok(1).expect('should be Ok()'), equals(1));
-			expect(() => Err('foo').expect('Should be Ok()'), throwsA(TypeMatcher<ResultError>()));
-		});
-
-		test('Should return expected values from Result#expectErr()', () {
-			expect(Err(1).expectErr('should be Err()'), equals(1));
-			expect(() => Ok('foo').expectErr('Should be Err()'), throwsA(TypeMatcher<ResultError>()));
-		});
-
-		test('Should iterate over the held value via Result#iter()', () {
-			Result<int, String> foo = Ok(1);
-			Result<int, String> bar = Err('foo');
-
-			for (int value in foo.iter()) {
-				expect(value, equals(1));
-			}
-
-			bool called = false;
-			void call() => called = true;
-
-			// The call() function should not run since there's nothing to iterate
-			// over in an Err() value
-			for (int _ in bar.iter()) {
-				call();
-			}
-
-			expect(called, equals(false));
-		});
-
-		test('Should return expected values from Result#and()', () {
-			Result<int, String> foo = Ok(1);
-			Result<int, String> bar = Err('bar');
-
-			expect(foo.and(Ok(2)), equals(Ok<int, String>(2)));
-			expect(bar.and(Ok(2)), equals(Err<int, String>('bar')));
-
-			expect(foo.and(Ok('foo')), equals(Ok<String, String>('foo')));
-			expect(bar.and(Ok('baz')), equals(Err<String, String>('bar')));
-		});
-
-		test('Should return expected values from Result#andThen()', () {
-			Result<int, String> foo = Ok(1);
-			Result<int, String> bar = Err('bar');
-
-			expect(foo.andThen((value) => Ok(value * 2)), equals(Ok<int, String>(2)));
-			expect(bar.andThen((value) => Ok(value * 2)), equals(Err<int, String>('bar')));
-
-			expect(foo.andThen((value) => Ok(value.toString())), equals(Ok<String, String>('1')));
-			expect(bar.andThen((value) => Ok(value.toString())), equals(Err<String, String>('bar')));
-		});
-
-		test('Should return expected values from Result#or()', () {
-			Result<int, String> foo = Ok(1);
-			Result<int, String> bar = Err('bar');
-
-			expect(foo.or(Ok<int, String>(2)), equals(Ok<int, String>(1)));
-			expect(bar.or(Ok<int, String>(2)), equals(Ok<int, String>(2)));
-
-			expect(foo.or(Err(2)), equals(Ok<int, int>(1)));
-			expect(bar.or(Err(2)), equals(Err<int, int>(2)));
-		});
-
-		test('Should return expected values from Result#orElse()', () {
-			Result<int, String> foo = Ok(1);
-			Result<int, String> bar = Err('bar');
-
-			expect(foo.orElse((value) => Err('$value baz')), equals(Ok<int, String>(1)));
-			expect(bar.orElse((value) => Err('$value baz')), equals(Err<int, String>('bar baz')));
-
-			expect(foo.orElse((_) => Err(2)), equals(Ok<int, int>(1)));
-			expect(bar.orElse((_) => Err(2)), equals(Err<int, int>(2)));
-		});
-
-		test('Should execute the given function and return self as expected in Result#inspect()', () {
-			bool called = false;
-
-			void inspectFn(_) {
-				called = true;
-			}
-
-			Result<int, String> foo = Ok(1);
-
-			int bar = foo.inspect(inspectFn).unwrap();
-
-			expect(bar, equals(1));
-			expect(called, equals(true));
-		});
-
-		test('Should execute the given function and return self as expected in Result#inspectErr()', () {
-			bool called = false;
-
-			void inspectFn(_) {
-				called = true;
-			}
-
-			Result<int, String> foo = Err('foo');
-
-			String bar = foo.inspectErr(inspectFn).unwrapErr();
-
-			expect(bar, equals('foo'));
-			expect(called, equals(true));
-		});
-
-		test('Should return expected values from Result#map()', () {
-			Result<int, String> foo = Ok(5);
-
-			expect(foo.map((value) => value * 10), equals(Ok<int, String>(50)));
-			expect(foo.map((value) => value.toString()), equals(Ok<String, String>('5')));
-
-			expect(foo.map((value) => [value]), equals(TypeMatcher<Ok<List<int>, String>>()));
-
-			// Check the wrapped List directly because two Results holding
-			// different references to visibly identical lists aren't equatable
-			expect(foo.map((value) => [value]).unwrap(), equals([5]));
-
-			Result<int, String> bar = Err('bar');
-
-			expect(bar.map((value) => value.toString()), equals(Err<String, String>('bar')));
-		});
-
-		test('Should return expected values from Result#mapOr()', () {
-			Result<int, String> a = Ok(1);
-			Result<int, String> b = Err('foo');
-
-			expect(a.mapOr(5, (val) => val + 1), equals(Ok<int, String>(2)));
-			expect(b.mapOr(5, (val) => val + 1), equals(Ok<int, String>(5)));
-		});
-
-		test('Should return expected values from Result#mapOrElse()', () {
-			Result<int, String> a = Ok(1);
-			Result<int, String> b = Err('foo');
-
-			expect(a.mapOrElse(() => 5, (val) => val + 1), equals(Ok<int, String>(2)));
-			expect(b.mapOrElse(() => 5, (val) => val + 1), equals(Ok<int, String>(5)));
-		});
-
-		test('Should return expected values from Result#mapErr()', () {
-			Result<int, String> foo = Err('foo');
-
-			expect(foo.mapErr((value) => value * 3), equals(Err<int, String>('foofoofoo')));
-			expect(foo.mapErr((value) => value.toUpperCase()), equals(Err<int, String>('FOO')));
-
-			expect(foo.mapErr((value) => [value]), equals(TypeMatcher<Err<int, List<String>>>()));
-
-			// Check the wrapped List directly because two Results holding
-			// different references to visibly identical lists aren't equatable
-			expect(foo.mapErr((value) => [value]).unwrapErr(), equals(['foo']));
-		});
-
-		test('Should return expected values from Result#flatten()', () {
-			Result<Result<Result<Result<int, String>, String>, String>, String> foo = Ok(Ok(Ok(Ok(1))));
-
-			// Result.from() here because it won't equate Ok<Ok<T, E>, E> to Result<Result<T, E>, E>
-			// but Result<Result<T, E>, E> compares fine. I assumed it was from the runtimeType
-			// comparison in == but removing that still doesn't allow equals() to consider
-			// the values the same here despite that fixing == for these cases.
-			expect(foo.flatten().flatten().flatten(), equals(Ok<int, String>(1)));
-			expect(foo.flatten().flatten(), equals(Result.from(Result.from(1, 'foo'), 'bar')));
-			expect(foo.flatten(), equals(Result.from(Result.from(Result.from(1, 'foo'), 'bar'), 'baz')));
-
-			var bar = Ok(Ok(Ok(Ok(1))));
-
-			expect(bar.flatten().flatten().flatten(), equals(Ok(1)));
-
-			Result<Result<int, String>, String> baz = Err('baz');
-
-			expect(baz.flatten(), equals(Err<int, String>('baz')));
-		});
-
-		test('Should return expected values from Result#ok()', () {
-			Result<int, String> foo = Ok(1);
-			Result<int, String> bar = Err('bar');
-
-			expect(foo.ok(), equals(Some(1)));
-			expect(bar.ok(), equals(None<int>()));
-		});
-
-		test('Should return expected values from Result#err()', () {
-			Result<int, String> foo = Ok(1);
-			Result<int, String> bar = Err('bar');
-
-			expect(foo.err(), equals(None<String>()));
-			expect(bar.err(), equals(Some('bar')));
-		});
-
-		test('Should return expected values from Result#transpose()', () {
-			Result<Option<int>, String> foo = Ok(Some(1));
-			Result<Option<int>, String> bar = Ok(None());
-			Result<Option<int>, String> baz = Err('baz');
-
-			expect(foo.transpose(), equals(Some<Result<int, String>>(Ok(1))));
-			expect(bar.transpose(), equals(None<Result<int, String>>()));
-			expect(baz.transpose(), equals(Some<Result<int, String>>(Err('baz'))));
-		});
-	});
-
-	group('ResultError:', () {
-		test('Should return expected values from ResultError#toString()', () {
-			ResultError foo = ResultError(null);
-			ResultError bar = ResultError('bar');
-
-			expect(foo.toString(), equals('ResultError'));
-			expect(bar.toString(), equals('ResultError: bar'));
-		});
-	});
+      expect(foo.and(Ok(2)), equals(Ok<int, String>(2)));
+      expect(bar.and(Ok(2)), equals(Err<int, String>('bar')));
+
+      expect(foo.and(Ok('foo')), equals(Ok<String, String>('foo')));
+      expect(bar.and(Ok('baz')), equals(Err<String, String>('bar')));
+    });
+
+    test('Should return expected values from Result#andThen()', () {
+      Result<int, String> foo = Ok(1);
+      Result<int, String> bar = Err('bar');
+
+      expect(foo.andThen((value) => Ok(value * 2)), equals(Ok<int, String>(2)));
+      expect(bar.andThen((value) => Ok(value * 2)),
+          equals(Err<int, String>('bar')));
+
+      expect(foo.andThen((value) => Ok(value.toString())),
+          equals(Ok<String, String>('1')));
+      expect(bar.andThen((value) => Ok(value.toString())),
+          equals(Err<String, String>('bar')));
+    });
+
+    test('Should return expected values from Result#or()', () {
+      Result<int, String> foo = Ok(1);
+      Result<int, String> bar = Err('bar');
+
+      expect(foo.or(Ok<int, String>(2)), equals(Ok<int, String>(1)));
+      expect(bar.or(Ok<int, String>(2)), equals(Ok<int, String>(2)));
+
+      expect(foo.or(Err(2)), equals(Ok<int, int>(1)));
+      expect(bar.or(Err(2)), equals(Err<int, int>(2)));
+    });
+
+    test('Should return expected values from Result#orElse()', () {
+      Result<int, String> foo = Ok(1);
+      Result<int, String> bar = Err('bar');
+
+      expect(
+          foo.orElse((value) => Err('$value baz')), equals(Ok<int, String>(1)));
+      expect(bar.orElse((value) => Err('$value baz')),
+          equals(Err<int, String>('bar baz')));
+
+      expect(foo.orElse((_) => Err(2)), equals(Ok<int, int>(1)));
+      expect(bar.orElse((_) => Err(2)), equals(Err<int, int>(2)));
+    });
+
+    test(
+        'Should execute the given function and return self as expected in Result#inspect()',
+        () {
+      bool called = false;
+
+      void inspectFn(_) {
+        called = true;
+      }
+
+      Result<int, String> foo = Ok(1);
+
+      int bar = foo.inspect(inspectFn).unwrap();
+
+      expect(bar, equals(1));
+      expect(called, equals(true));
+    });
+
+    test(
+        'Should execute the given function and return self as expected in Result#inspectErr()',
+        () {
+      bool called = false;
+
+      void inspectFn(_) {
+        called = true;
+      }
+
+      Result<int, String> foo = Err('foo');
+
+      String bar = foo.inspectErr(inspectFn).unwrapErr();
+
+      expect(bar, equals('foo'));
+      expect(called, equals(true));
+    });
+
+    test('Should return expected values from Result#map()', () {
+      Result<int, String> foo = Ok(5);
+
+      expect(foo.map((value) => value * 10), equals(Ok<int, String>(50)));
+      expect(foo.map((value) => value.toString()),
+          equals(Ok<String, String>('5')));
+
+      expect(foo.map((value) => [value]),
+          equals(TypeMatcher<Ok<List<int>, String>>()));
+
+      // Check the wrapped List directly because two Results holding
+      // different references to visibly identical lists aren't equatable
+      expect(foo.map((value) => [value]).unwrap(), equals([5]));
+
+      Result<int, String> bar = Err('bar');
+
+      expect(bar.map((value) => value.toString()),
+          equals(Err<String, String>('bar')));
+    });
+
+    test('Should return expected values from Result#mapOr()', () {
+      Result<int, String> a = Ok(1);
+      Result<int, String> b = Err('foo');
+
+      expect(a.mapOr(5, (val) => val + 1), equals(Ok<int, String>(2)));
+      expect(b.mapOr(5, (val) => val + 1), equals(Ok<int, String>(5)));
+    });
+
+    test('Should return expected values from Result#mapOrElse()', () {
+      Result<int, String> a = Ok(1);
+      Result<int, String> b = Err('foo');
+
+      expect(
+          a.mapOrElse(() => 5, (val) => val + 1), equals(Ok<int, String>(2)));
+      expect(
+          b.mapOrElse(() => 5, (val) => val + 1), equals(Ok<int, String>(5)));
+    });
+
+    test('Should return expected values from Result#mapErr()', () {
+      Result<int, String> foo = Err('foo');
+
+      expect(foo.mapErr((value) => value * 3),
+          equals(Err<int, String>('foofoofoo')));
+      expect(foo.mapErr((value) => value.toUpperCase()),
+          equals(Err<int, String>('FOO')));
+
+      expect(foo.mapErr((value) => [value]),
+          equals(TypeMatcher<Err<int, List<String>>>()));
+
+      // Check the wrapped List directly because two Results holding
+      // different references to visibly identical lists aren't equatable
+      expect(foo.mapErr((value) => [value]).unwrapErr(), equals(['foo']));
+    });
+
+    test('Should return expected values from Result#flatten()', () {
+      Result<Result<Result<Result<int, String>, String>, String>, String> foo =
+          Ok(Ok(Ok(Ok(1))));
+
+      // Result.from() here because it won't equate Ok<Ok<T, E>, E> to Result<Result<T, E>, E>
+      // but Result<Result<T, E>, E> compares fine. I assumed it was from the runtimeType
+      // comparison in == but removing that still doesn't allow equals() to consider
+      // the values the same here despite that fixing == for these cases.
+      expect(foo.flatten().flatten().flatten(), equals(Ok<int, String>(1)));
+      expect(foo.flatten().flatten(),
+          equals(Result.from(Result.from(1, 'foo'), 'bar')));
+      expect(
+          foo.flatten(),
+          equals(
+              Result.from(Result.from(Result.from(1, 'foo'), 'bar'), 'baz')));
+
+      var bar = Ok(Ok(Ok(Ok(1))));
+
+      expect(bar.flatten().flatten().flatten(), equals(Ok(1)));
+
+      Result<Result<int, String>, String> baz = Err('baz');
+
+      expect(baz.flatten(), equals(Err<int, String>('baz')));
+    });
+
+    test('Should return expected values from Result#ok()', () {
+      Result<int, String> foo = Ok(1);
+      Result<int, String> bar = Err('bar');
+
+      expect(foo.ok(), equals(Some(1)));
+      expect(bar.ok(), equals(None<int>()));
+    });
+
+    test('Should return expected values from Result#err()', () {
+      Result<int, String> foo = Ok(1);
+      Result<int, String> bar = Err('bar');
+
+      expect(foo.err(), equals(None<String>()));
+      expect(bar.err(), equals(Some('bar')));
+    });
+
+    test('Should return expected values from Result#transpose()', () {
+      Result<Option<int>, String> foo = Ok(Some(1));
+      Result<Option<int>, String> bar = Ok(None());
+      Result<Option<int>, String> baz = Err('baz');
+
+      expect(foo.transpose(), equals(Some<Result<int, String>>(Ok(1))));
+      expect(bar.transpose(), equals(None<Result<int, String>>()));
+      expect(baz.transpose(), equals(Some<Result<int, String>>(Err('baz'))));
+    });
+  });
+
+  group('ResultError:', () {
+    test('Should return expected values from ResultError#toString()', () {
+      ResultError foo = ResultError(null);
+      ResultError bar = ResultError('bar');
+
+      expect(foo.toString(), equals('ResultError'));
+      expect(bar.toString(), equals('ResultError: bar'));
+    });
+  });
 }


### PR DESCRIPTION
This pull request removes all additional getters and retains only the one associated with the field name. It is advisable to use uniform getters for consistency. If additional getters are desired, extensions can be made on a project basis.

I would stick to just `v` for `Option` and `Ok`, and `e` for `Err` because they are concise and because this makes using pattern matching more straightforward. E.g. the following snippet

```dart
print(switch (foo) {
  Some(value: var bar) => 'Some value: $bar',
  None() => 'No value!'
});
```

is more verbose than the next one

```dart
print(switch (foo) {
  Some(v: var bar) => 'Some value: $bar',
  None() => 'No value!'
});
```

I also believe, for example, that having one field with four getters for 'Err' is a bit excessive.

What is your opinion on this?

Note: dart formatted the source code and replaced tabs with empty spaces.