### PR TITLE
 Add variable names to function parameters in types

### DIFF
--- a/lib/src/option/option.dart
+++ b/lib/src/option/option.dart
@@ -94,7 +94,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::is_some_and()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some_and)
-	bool isSomeAnd(bool Function(T) predicate) => switch (this) {
+	bool isSomeAnd(bool Function(T v) predicate) => switch (this) {
 		Some(:T v) => predicate(v),
 		None() => false
 	};
@@ -176,7 +176,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::and_then()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then)
-	Option<U> andThen<U>(Option<U> Function(T) fn) => switch (this) {
+	Option<U> andThen<U>(Option<U> Function(T v) fn) => switch (this) {
 		Some(:T v) => fn(v),
 		None() => None()
 	};
@@ -233,7 +233,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::inspect()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.inspect)
-	Option<T> inspect(void Function(T) fn) {
+	Option<T> inspect(void Function(T v) fn) {
 		if (this case Some(:T v)) {
 			fn(v);
 		}
@@ -251,7 +251,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::filter()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.filter)
-	Option<T> where(bool Function(T) predicate) => switch (this) {
+	Option<T> where(bool Function(T v) predicate) => switch (this) {
 		Some(:T v) => predicate(v) ? this : None(),
 		None() => this
 	};
@@ -265,7 +265,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::map()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map)
-	Option<U> map<U>(U Function(T) mapFn) => switch (this) {
+	Option<U> map<U>(U Function(T v) mapFn) => switch (this) {
 		Some(:T v) => Some(mapFn(v)),
 		None() => None()
 	};
@@ -292,7 +292,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::map_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or)
-	Option<U> mapOr<U>(U orValue, U Function(T) mapFn) => switch (this) {
+	Option<U> mapOr<U>(U orValue, U Function(T v) mapFn) => switch (this) {
 		Some(:T v) => Some(mapFn(v)),
 		None() => Some(orValue)
 	};
@@ -318,7 +318,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::map_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or_else)
-	Option<U> mapOrElse<U>(U Function() orFn, U Function(T) mapFn) => switch (this) {
+	Option<U> mapOrElse<U>(U Function() orFn, U Function(T v) mapFn) => switch (this) {
 		Some(:T v) => Some(mapFn(v)),
 		None() => Some(orFn())
 	};
@@ -347,7 +347,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::zip_with()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.zip_with)
-	Option<V> zipWith<U, V>(Option<U> other, V Function(T, U) zipFn) => switch ((this, other)) {
+	Option<V> zipWith<U, V>(Option<U> other, V Function(T v, U o) zipFn) => switch ((this, other)) {
 		(Some(v: T a), Some(v: U b)) => Some(zipFn(a, b)),
 		_ => None()
 	};

--- a/lib/src/result/result.dart
+++ b/lib/src/result/result.dart
@@ -99,7 +99,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::is_ok_and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok_and)
-	bool isOkAnd(bool Function(T) predicate) => switch (this) {
+	bool isOkAnd(bool Function(T v) predicate) => switch (this) {
 		Ok(:T v) => predicate(v),
 		Err() => false
 	};
@@ -119,7 +119,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::is_err_and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err_and)
-	bool isErrAnd(bool Function(E) predicate) => switch (this) {
+	bool isErrAnd(bool Function(E e) predicate) => switch (this) {
 		Ok() => false,
 		Err(:E e) => predicate(e)
 	};
@@ -221,7 +221,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::and_then()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.and_then)
-	Result<U, E> andThen<U>(Result<U, E> Function(T) fn) => switch (this) {
+	Result<U, E> andThen<U>(Result<U, E> Function(T v) fn) => switch (this) {
 		Ok(:T v) => fn(v),
 		Err(:E e) => Err(e)
 	};
@@ -241,7 +241,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.or_else)
-	Result<T, F> orElse<F>(Result<T, F> Function(E) fn) => switch (this) {
+	Result<T, F> orElse<F>(Result<T, F> Function(E e) fn) => switch (this) {
 		Ok(:T v) => Ok(v),
 		Err(:E e) => fn(e)
 	};
@@ -261,7 +261,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::inspect()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect)
-	Result<T, E> inspect(void Function(T) fn) {
+	Result<T, E> inspect(void Function(T v) fn) {
 		if (this case Ok(:T v)) {
 			fn(v);
 		}
@@ -285,7 +285,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::inspect_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect_err)
-	Result<T, E> inspectErr(void Function(E) fn) {
+	Result<T, E> inspectErr(void Function(E e) fn) {
 		if (this case Err(:E e)) {
 			fn(e);
 		}
@@ -302,7 +302,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::map()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map)
-	Result<U, E> map<U>(U Function(T) mapFn) => switch (this) {
+	Result<U, E> map<U>(U Function(T v) mapFn) => switch (this) {
 		Ok(:T v) => Ok(mapFn(v)),
 		Err(:E e) => Err(e)
 	};
@@ -329,7 +329,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::map_or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or)
-	Result<U, E> mapOr<U>(U orValue, U Function(T) mapFn) => switch (this) {
+	Result<U, E> mapOr<U>(U orValue, U Function(T v) mapFn) => switch (this) {
 		Ok(:T v) => Ok(mapFn(v)),
 		Err() => Ok(orValue)
 	};
@@ -355,7 +355,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::map_or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else)
-	Result<U, E> mapOrElse<U>(U Function() orFn, U Function(T) mapFn) => switch (this) {
+	Result<U, E> mapOrElse<U>(U Function() orFn, U Function(T v) mapFn) => switch (this) {
 		Ok(:T v) => Ok(mapFn(v)),
 		Err() => Ok(orFn())
 	};
@@ -369,7 +369,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::map_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err)
-	Result<T, F> mapErr<F>(F Function(E) mapFn) => switch (this) {
+	Result<T, F> mapErr<F>(F Function(E e) mapFn) => switch (this) {
 		Ok(:T v) => Ok(v),
 		Err(:E e) => Err(mapFn(e))
 	};


### PR DESCRIPTION
Adding variable names to function parameters in types prevents autocomplete from producing unsatisfying parameters such as `(p0)`.

Added variable names:
- `T v`
- `E e`
- `U o` (for other in `zipWith`)