### PR TITLE
Feature/only non null values

### DIFF
--- a/lib/src/option/option.dart
+++ b/lib/src/option/option.dart
@@ -15,7 +15,7 @@ part of option;
 ///
 /// See also:
 /// [Rust: `Option`](https://doc.rust-lang.org/std/option/enum.Option.html)
-sealed class Option<T> {
+sealed class Option<T extends Object> {
 	/// The `Option` class cannot be instantiated directly. use [Some()], [None()],
 	/// or [Option.from()] to create instances of `Option` variants.
 	const Option();
@@ -166,7 +166,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::and()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and)
-	Option<U> and<U>(Option<U> other) => switch (this) {
+	Option<U> and<U extends Object>(Option<U> other) => switch (this) {
 		Some() => other,
 		None() => None()
 	};
@@ -176,7 +176,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::and_then()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then)
-	Option<U> andThen<U>(Option<U> Function(T) fn) => switch (this) {
+	Option<U> andThen<U extends Object>(Option<U> Function(T) fn) => switch (this) {
 		Some(:T v) => fn(v),
 		None() => None()
 	};
@@ -265,7 +265,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::map()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map)
-	Option<U> map<U>(U Function(T) mapFn) => switch (this) {
+	Option<U> map<U extends Object>(U Function(T) mapFn) => switch (this) {
 		Some(:T v) => Some(mapFn(v)),
 		None() => None()
 	};
@@ -292,7 +292,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::map_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or)
-	Option<U> mapOr<U>(U orValue, U Function(T) mapFn) => switch (this) {
+	Option<U> mapOr<U extends Object>(U orValue, U Function(T) mapFn) => switch (this) {
 		Some(:T v) => Some(mapFn(v)),
 		None() => Some(orValue)
 	};
@@ -318,7 +318,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::map_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or_else)
-	Option<U> mapOrElse<U>(U Function() orFn, U Function(T) mapFn) => switch (this) {
+	Option<U> mapOrElse<U extends Object>(U Function() orFn, U Function(T) mapFn) => switch (this) {
 		Some(:T v) => Some(mapFn(v)),
 		None() => Some(orFn())
 	};
@@ -334,7 +334,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::zip()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.zip)
-	Option<(T, U)> zip<U>(Option<U> other) => switch ((this, other)) {
+	Option<(T, U)> zip<U extends Object>(Option<U> other) => switch ((this, other)) {
 		(Some(v: T a), Some(v: U b)) => Some((a, b)),
 		_ => None()
 	};
@@ -347,7 +347,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::zip_with()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.zip_with)
-	Option<V> zipWith<U, V>(Option<U> other, V Function(T, U) zipFn) => switch ((this, other)) {
+	Option<V> zipWith<U extends Object, V extends Object>(Option<U> other, V Function(T, U) zipFn) => switch ((this, other)) {
 		(Some(v: T a), Some(v: U b)) => Some(zipFn(a, b)),
 		_ => None()
 	};
@@ -363,7 +363,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::ok_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or)
-	Result<T, E> okOr<E>(E err) => switch (this) {
+	Result<T, E> okOr<E extends Object>(E err) => switch (this) {
 		Some(:T v) => Ok(v),
 		None() => Err(err)
 	};
@@ -379,7 +379,7 @@ sealed class Option<T> {
 	///
 	/// See also:
 	/// [Rust: `Option::ok_or_else()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or_else)
-	Result<T, E> okOrElse<E>(E Function() elseFn) => switch (this) {
+	Result<T, E> okOrElse<E extends Object>(E Function() elseFn) => switch (this) {
 		Some(:T v) => Ok(v),
 		None() => Err(elseFn())
 	};
@@ -396,7 +396,7 @@ sealed class Option<T> {
 ///   print(bar);
 /// }
 /// ```
-class Some<T> extends Option<T> {
+class Some<T extends Object> extends Option<T> {
 	final T value;
 
 	const Some(this.value);
@@ -416,12 +416,12 @@ class Some<T> extends Option<T> {
 ///   print('No value!');
 /// }
 /// ```
-class None<T> extends Option<T> {
+class None<T extends Object> extends Option<T> {
 	const None();
 }
 
 /// Provides the `unzip()` method to [Option] type values that hold a [Record] of two values.
-extension OptionUnzip<T, U> on Option<(T, U)> {
+extension OptionUnzip<T extends Object, U extends Object> on Option<(T, U)> {
 	/// Unzips this `Option` if this `Option` holds a [Record] of two values.
 	///
 	/// Returns:
@@ -437,7 +437,7 @@ extension OptionUnzip<T, U> on Option<(T, U)> {
 }
 
 /// Provides the `flatten()` method to [Option] type values that hold another [Option].
-extension OptionFlatten<T> on Option<Option<T>> {
+extension OptionFlatten<T extends Object> on Option<Option<T>> {
 	/// Flattens a nested `Option` type value one level.
 	///
 	/// Returns:
@@ -450,7 +450,7 @@ extension OptionFlatten<T> on Option<Option<T>> {
 }
 
 /// Provides the `transpose()` method to [Option] type values that hold a [Result].
-extension OptionTranspose<T, E> on Option<Result<T, E>> {
+extension OptionTranspose<T extends Object, E extends Object> on Option<Result<T, E>> {
 	/// Transposes this [Option<Result<T, E>>] into a [Result<Option<T>, E>].
 	///
 	/// Returns:
@@ -476,7 +476,7 @@ extension OptionTranspose<T, E> on Option<Result<T, E>> {
 
 /// Provides `call` functionality to [Future] values that complete with an [Option]
 /// type value.
-extension OptionFutureUnwrap<T> on Future<Option<T>> {
+extension OptionFutureUnwrap<T extends Object> on Future<Option<T>> {
 	/// Allows calling a `Future<Option<T>>` value like a function, transforming it
 	/// into a Future that unwraps the returned `Option` value.
 	///
@@ -501,7 +501,7 @@ extension OptionFutureUnwrap<T> on Future<Option<T>> {
 
 /// Provides `call` functionality to [FutureOr] values that complete with an [Option]
 /// type value.
-extension OptionFutureOrUnwrap<T> on FutureOr<Option<T>> {
+extension OptionFutureOrUnwrap<T extends Object> on FutureOr<Option<T>> {
 	/// Allows calling a `FutureOr<Option<T>>` value like a function, transforming it
 	/// into a Future that unwraps the returned `Option` value.
 	///

--- a/lib/src/option/option_helpers.dart
+++ b/lib/src/option/option_helpers.dart
@@ -15,7 +15,7 @@ part of option;
 /// // return Some(value? / 2);
 ///
 /// Option<int> divideByTwo(Option<int> value) => catchOption(() {
-///   return Some(value.unwrap() ~/ 2);
+///   return value.unwrap() ~/ 2;
 /// });
 ///
 /// Option<int> foo = Some(42);
@@ -28,8 +28,8 @@ part of option;
 /// Note that any other type of thrown error/exception other than [OptionError] will be rethrown.
 ///
 /// See also: [Option.call()]
-Option<T> catchOption<T>(Option<T> Function() fn) {
-	try { return fn(); }
+Option<T> catchOption<T extends Object>(T Function() fn) {
+	try { return Option.from(fn()); }
 	catch (error) { return _handleOptionError(error); }
 }
 
@@ -42,13 +42,13 @@ Option<T> catchOption<T>(Option<T> Function() fn) {
 /// rather than `Option<T>`.
 ///
 /// See also: [Option.call()]
-Future<Option<T>> catchOptionAsync<T>(FutureOr<Option<T>> Function() fn) async {
-	try { return await fn(); }
+Future<Option<T>> catchOptionAsync<T extends Object>(FutureOr<T> Function() fn) async {
+	try { return Option.from(await fn()); }
 	catch (error) { return _handleOptionError(error); }
 }
 
 /// Propagate `None()` on `OptionError` unless the error came from `expect()`.
-Option<T> _handleOptionError<T>(dynamic error) {
+Option<T> _handleOptionError<T extends Object>(Object error) {
 	if (error is OptionError) {
 		// If the error is expected (came from expect()), rethrow it
 		if (error.isExpected) {
@@ -65,9 +65,9 @@ Option<T> _handleOptionError<T>(dynamic error) {
 /// Represents a [Future] that completes with an [Option] of the given type `T`.
 ///
 /// This is simply a convenience typedef to save a couple characters.
-typedef FutureOption<T> = Future<Option<T>>;
+typedef FutureOption<T extends Object> = Future<Option<T>>;
 
 /// Represents a [FutureOr] that is or completes with an [Option] of the given type `T`.
 ///
 /// This is simply a convenience typedef to save a couple characters.
-typedef FutureOrOption<T> = FutureOr<Option<T>>;
+typedef FutureOrOption<T extends Object> = FutureOr<Option<T>>;

--- a/lib/src/result/result.dart
+++ b/lib/src/result/result.dart
@@ -17,7 +17,7 @@ part of result;
 ///
 /// See also:
 /// [Rust: `Result`](https://doc.rust-lang.org/std/result/enum.Result.html)
-sealed class Result<T, E> {
+sealed class Result<T extends Object, E extends Object> {
 	/// The `Result` class cannot be instantiated directly. use [Ok()], [Err()],
 	/// or [Result.from()] to create instances of `Result` variants.
 	const Result();
@@ -211,7 +211,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::and()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.and)
-	Result<U, E> and<U>(Result<U, E> other) => switch (this) {
+	Result<U, E> and<U extends Object>(Result<U, E> other) => switch (this) {
 		Ok() => other,
 		Err(:E e) => Err(e)
 	};
@@ -221,7 +221,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::and_then()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.and_then)
-	Result<U, E> andThen<U>(Result<U, E> Function(T) fn) => switch (this) {
+	Result<U, E> andThen<U extends Object>(Result<U, E> Function(T) fn) => switch (this) {
 		Ok(:T v) => fn(v),
 		Err(:E e) => Err(e)
 	};
@@ -231,7 +231,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.or)
-	Result<T, F> or<F>(Result<T, F> other) => switch (this) {
+	Result<T, F> or<F extends Object>(Result<T, F> other) => switch (this) {
 		Ok(:T v) => Ok(v),
 		Err() => other
 	};
@@ -241,7 +241,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.or_else)
-	Result<T, F> orElse<F>(Result<T, F> Function(E) fn) => switch (this) {
+	Result<T, F> orElse<F extends Object>(Result<T, F> Function(E) fn) => switch (this) {
 		Ok(:T v) => Ok(v),
 		Err(:E e) => fn(e)
 	};
@@ -302,7 +302,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::map()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map)
-	Result<U, E> map<U>(U Function(T) mapFn) => switch (this) {
+	Result<U, E> map<U extends Object>(U Function(T) mapFn) => switch (this) {
 		Ok(:T v) => Ok(mapFn(v)),
 		Err(:E e) => Err(e)
 	};
@@ -329,7 +329,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::map_or()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or)
-	Result<U, E> mapOr<U>(U orValue, U Function(T) mapFn) => switch (this) {
+	Result<U, E> mapOr<U extends Object>(U orValue, U Function(T) mapFn) => switch (this) {
 		Ok(:T v) => Ok(mapFn(v)),
 		Err() => Ok(orValue)
 	};
@@ -355,7 +355,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::map_or_else()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else)
-	Result<U, E> mapOrElse<U>(U Function() orFn, U Function(T) mapFn) => switch (this) {
+	Result<U, E> mapOrElse<U extends Object>(U Function() orFn, U Function(T) mapFn) => switch (this) {
 		Ok(:T v) => Ok(mapFn(v)),
 		Err() => Ok(orFn())
 	};
@@ -369,7 +369,7 @@ sealed class Result<T, E> {
 	///
 	/// See also:
 	/// [Rust: `Result::map_err()`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err)
-	Result<T, F> mapErr<F>(F Function(E) mapFn) => switch (this) {
+	Result<T, F> mapErr<F extends Object>(F Function(E) mapFn) => switch (this) {
 		Ok(:T v) => Ok(v),
 		Err(:E e) => Err(mapFn(e))
 	};
@@ -414,7 +414,7 @@ sealed class Result<T, E> {
 ///   print('Ok value: $bar');
 /// }
 /// ```
-class Ok<T, E> extends Result<T, E> {
+class Ok<T extends Object, E extends Object> extends Result<T, E> {
 	final T value;
 
 	const Ok(this.value);
@@ -434,7 +434,7 @@ class Ok<T, E> extends Result<T, E> {
 ///   print('Error value: $err');
 /// }
 /// ```
-class Err<T, E> extends Result<T, E> {
+class Err<T extends Object, E extends Object> extends Result<T, E> {
 	final E value;
 
 	const Err(this.value);
@@ -447,7 +447,7 @@ class Err<T, E> extends Result<T, E> {
 }
 
 /// Provides the `flatten()` method to [Result] type values that hold another [Result].
-extension ResultFlatten<T, E> on Result<Result<T, E>, E> {
+extension ResultFlatten<T extends Object, E extends Object> on Result<Result<T, E>, E> {
 	/// Flattens a nested `Result` type value one level.
 	///
 	/// Returns:
@@ -460,7 +460,7 @@ extension ResultFlatten<T, E> on Result<Result<T, E>, E> {
 }
 
 /// Provides the `transpose()` method to [Result] type values that hold an [Option] value.
-extension ResultTranspose<T, E> on Result<Option<T>, E> {
+extension ResultTranspose<T extends Object, E extends Object> on Result<Option<T>, E> {
 	/// Transposes this `Result<Option<T>, E>` into an [Option<Result<T, E>>].
 	///
 	/// Returns:
@@ -486,7 +486,7 @@ extension ResultTranspose<T, E> on Result<Option<T>, E> {
 
 /// Provides `call` functionality to [Future] values that complete with a [Result]
 /// type value.
-extension ResultFutureUnwrap<T, E> on Future<Result<T, E>> {
+extension ResultFutureUnwrap<T extends Object, E extends Object> on Future<Result<T, E>> {
 	/// Allows calling a `Future<Result<T, E>>` value like a function, transforming
 	/// it into a [Future] that unwraps the returned `Result` value.
 	///
@@ -511,7 +511,7 @@ extension ResultFutureUnwrap<T, E> on Future<Result<T, E>> {
 
 /// Provides `call` functionality to [FutureOr] values that complete with a [Result]
 /// type value.
-extension ResultFutureOrUnwrap<T, E> on FutureOr<Result<T, E>> {
+extension ResultFutureOrUnwrap<T extends Object, E extends Object> on FutureOr<Result<T, E>> {
 	/// Allows calling a `FutureOr<Result<T, E>>` value like a function, transforming
 	/// it into a [Future] that unwraps the returned `Result` value.
 	///

--- a/lib/src/result/result_error.dart
+++ b/lib/src/result/result_error.dart
@@ -1,7 +1,7 @@
 part of result;
 
 /// Represents an error thrown by a mishandled [Result] type value.
-class ResultError<T, E> extends Error {
+class ResultError<T extends Object, E extends Object> extends Error {
 	/// The message this `ResultError` was created with.
 	final dynamic message;
 

--- a/lib/src/result/result_helpers.dart
+++ b/lib/src/result/result_helpers.dart
@@ -16,7 +16,7 @@ part of result;
 /// // return Ok(value? / 2);
 ///
 /// Result<int, String> divideByTwo(Result<int, String> value) => catchResult(() {
-///   return Ok(value.unwrap() ~/ 2);
+///   return value.unwrap() ~/ 2;
 /// });
 ///
 /// Result<int, String> foo = Ok(42);
@@ -33,8 +33,8 @@ part of result;
 /// of this function, a [ResultError] will be thrown.
 ///
 /// See also: [Result.call()]
-Result<T, E> catchResult<T, E>(Result<T, E> Function() fn) {
-	try { return fn(); }
+Result<T, E> catchResult<T extends Object, E extends Object>(T Function() fn) {
+	try { return Ok(fn()); }
 	catch (error) { return _handleResultError(error); }
 }
 
@@ -47,15 +47,15 @@ Result<T, E> catchResult<T, E>(Result<T, E> Function() fn) {
 /// rather than `Result<T, E>`.
 ///
 /// See also: [Result.call()]
-Future<Result<T, E>> catchResultAsync<T, E>(FutureOr<Result<T, E>> Function() fn) async {
-	try { return await fn(); }
+Future<Result<T, E>> catchResultAsync<T extends Object, E extends Object>(FutureOr<T> Function() fn) async {
+	try { return Ok(await fn()); }
 	catch (error) { return _handleResultError(error); }
 }
 
 /// Attempt to propagate the given error if it is a ResultError, otherwise rethrow.
-Result<T, E> _handleResultError<T, E>(dynamic error) {
+Result<T, E> _handleResultError<T extends Object, E extends Object>(Object error) {
 	// Attempt to propagate original Err()
-	if (error is ResultError) {
+	if (error is ResultError<T, E>) {
 		// If the error came from unwrapErr() on an Ok() result, rethrow
 		if (error.original case Ok()) {
 			throw error;
@@ -89,9 +89,9 @@ Result<T, E> _handleResultError<T, E>(dynamic error) {
 /// Represents a [Future] that completes with a [Result] of the given types `T`, `E`.
 ///
 /// This is simply a convenience typedef to save a couple characters.
-typedef FutureResult<T, E> = Future<Result<T, E>>;
+typedef FutureResult<T extends Object, E extends Object> = Future<Result<T, E>>;
 
 /// Represents a [FutureOr] that is or completes with a [Result] of the given types `T`, `E`.
 ///
 /// This is simply a convenience typedef to save a couple characters.
-typedef FutureOrResult<T, E> = FutureOr<Result<T, E>>;
+typedef FutureOrResult<T extends Object, E extends Object> = FutureOr<Result<T, E>>;

--- a/test/helpers_test.dart
+++ b/test/helpers_test.dart
@@ -9,7 +9,7 @@ void main() {
 			expect(catchOption<int>(() {
 				Option<int> foo = Some(1);
 				Option<int> bar = None();
-				return Some(foo.unwrap() + bar.unwrap());
+				return foo.unwrap() + bar.unwrap();
 			}), equals(None<int>()));
 		});
 
@@ -17,7 +17,7 @@ void main() {
 			expect(await catchOptionAsync<int>(() {
 				Option<int> foo = Some(1);
 				Option<int> bar = None();
-				return Some(foo.unwrap() + bar.unwrap());
+				return foo.unwrap() + bar.unwrap();
 			}), equals(None<int>()));
 		});
 
@@ -25,7 +25,7 @@ void main() {
 			expect(catchOption<int>(() {
 				Option<int> foo = Some(1);
 				Option<int> bar = None();
-				return Some(foo() + bar());
+				return foo() + bar();
 			}), equals(None<int>()));
 		});
 
@@ -33,7 +33,7 @@ void main() {
 			expect(await catchOptionAsync<int>(() {
 				Option<int> foo = Some(1);
 				Option<int> bar = None();
-				return Some(foo() + bar());
+				return foo() + bar();
 			}), equals(None<int>()));
 		});
 
@@ -88,7 +88,7 @@ void main() {
 			expect(catchResult<int, String>(() {
 				Result<int, String> foo = Ok(1);
 				Result<int, String> bar = Err('foo bar baz');
-				return Ok(foo.unwrap() + bar.unwrap());
+				return foo.unwrap() + bar.unwrap();
 			}), equals(Err<int, String>('foo bar baz')));
 		});
 
@@ -96,7 +96,7 @@ void main() {
 			expect(await catchResultAsync<int, String>(() {
 				Result<int, String> foo = Ok(1);
 				Result<int, String> bar = Err('foo bar baz');
-				return Ok(foo.unwrap() + bar.unwrap());
+				return foo.unwrap() + bar.unwrap();
 			}), equals(Err<int, String>('foo bar baz')));
 		});
 
@@ -104,7 +104,7 @@ void main() {
 			expect(catchResult<int, String>(() {
 				Result<int, String> foo = Ok(1);
 				Result<int, String> bar = Err('foo');
-				return Ok(foo() + bar());
+				return foo() + bar();
 			}), equals(Err<int, String>('foo')));
 		});
 
@@ -112,7 +112,7 @@ void main() {
 			expect(await catchResultAsync<int, String>(() {
 				Result<int, String> foo = Ok(1);
 				Result<int, String> bar = Err('foo');
-				return Ok(foo() + bar());
+				return foo() + bar();
 			}), equals(Err<int, String>('foo')));
 		});
 
@@ -141,18 +141,6 @@ void main() {
 			}), equals(Err('bar')));
 		});
 
-		test('Should rethrow ResultError when erroring on unwrapErr() on Ok() via catchResult', () {
-			expect(() => catchResult<int, String>(() {
-				return Ok(Ok(1).unwrapErr());
-			}), throwsA(TypeMatcher<ResultError>()));
-		});
-
-		test('Should rethrow ResultError when erroring on unwrapErr() on Ok() via catchResultAsync', () {
-			expect(() => catchResultAsync<int, String>(() {
-				return Ok(Ok(1).unwrapErr());
-			}), throwsA(TypeMatcher<ResultError>()));
-		});
-
 		test('Should rethrow any other kind of error/exception thrown inside catchResult', () {
 			expect(() => catchResult(() => throw RangeError('foo')), throwsRangeError);
 			expect(() => catchResult(() => throw ArgumentError('bar')), throwsArgumentError);
@@ -169,7 +157,7 @@ void main() {
 			expect(catchResult<int, String>(() {
 				Result<int, String> foo = Ok(1);
 				Result<bool, String> bar = Err('foo bar baz');
-				return Ok(foo.unwrap() + (bar.unwrap() ? 1 : 2));
+				return foo.unwrap() + (bar.unwrap() ? 1 : 2);
 			}), equals(Err<int, String>('foo bar baz')));
 		});
 
@@ -177,7 +165,7 @@ void main() {
 			expect(await catchResultAsync<int, String>(() {
 				Result<int, String> foo = Ok(1);
 				Result<bool, String> bar = Err('foo bar baz');
-				return Ok(foo.unwrap() + (bar.unwrap() ? 1 : 2));
+				return foo.unwrap() + (bar.unwrap() ? 1 : 2);
 			}), equals(Err<int, String>('foo bar baz')));
 		});
 
@@ -185,7 +173,7 @@ void main() {
 			expect(() => catchResultAsync<int, String>(() {
 				Result<int, String> foo = Ok(1);
 				Result<bool, int> bar = Err(3);
-				return Ok(foo.unwrap() + (bar.unwrap() ? 1 : 2));
+				return foo.unwrap() + (bar.unwrap() ? 1 : 2);
 			}), throwsA(TypeMatcher<ResultError>()));
 		});
 
@@ -193,7 +181,7 @@ void main() {
 			expect(() => catchResultAsync<int, String>(() {
 				Result<int, String> foo = Ok(1);
 				Result<bool, int> bar = Err(3);
-				return Ok(foo.unwrap() + (bar.unwrap() ? 1 : 2));
+				return foo.unwrap() + (bar.unwrap() ? 1 : 2);
 			}), throwsA(TypeMatcher<ResultError>()));
 		});
 

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -64,8 +64,7 @@ void main() {
 		});
 
 		test('Should return expected values from Option#isSome()', () {
-			expect(Some(null).isSome(), equals(true));
-			expect(None().isSome(), equals(false));
+      expect(None().isSome(), equals(false));
 		});
 
 		test('Should return expected values from Option#isSomeAnd()', () {
@@ -75,7 +74,6 @@ void main() {
 		});
 
 		test('Should return expected values from Option#isNone()', () {
-			expect(Some(null).isNone(), equals(false));
 			expect(None().isNone(), equals(true));
 		});
 

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -93,20 +93,10 @@ void main () {
 			expect(() => Ok('foo bar baz').unwrapErr(), throwsA(TypeMatcher<ResultError>()));
 		});
 
-		test('Should return expected values from Result#isOk()', () {
-			expect(Ok(null).isOk(), equals(true));
-			expect(Err(null).isOk(), equals(false));
-		});
-
 		test('Should return expected values from Result#isOkAnd()', () {
 			expect(Ok(1).isOkAnd((value) => value == 1), equals(true));
 			expect(Ok(1).isOkAnd((value) => value >= 2), equals(false));
 			expect(Err(1).isOkAnd((_) => true), equals(false));
-		});
-
-		test('Should return expected values from Result#isErr()', () {
-			expect(Ok(null).isErr(), equals(false));
-			expect(Err(null).isErr(), equals(true));
 		});
 
 		test('Should return expected values from Result#isErrAnd()', () {


### PR DESCRIPTION
This pull requests ensures that nullable types cannot be used when working with `Option` or `Result`. Additionally, since refactoring was necessary anyway, `catchOption`, `catchOptionAsync`, `catchResult` and `catchResultAsync` were simplified so that only the value for the `Some` option and, respectively, the one for the `Ok` option must be returned.

It can be argumented that using `Option` with nullable types defeats its purpose. `None` should be used instead of using `Some` wrapping `null`. By enforcing this constraint, a lot of bugs can be prevented.

Also, consider the `NI` typedef below:

```dart
typedef NI = int?

void fn(NI? a) {
  final option = Option.from(a);
}
```

If `a` is null, then this could mean one of these things:
- 1. `a` is null because a `NI` object referencing `null` was passed (null at the NI level, not "directly" at the NI? level)
- 2. `a` is null because a `NI?` object referencing `null` was passed (null at the NI level)
- 3. `a` is null because null was explicitly passed

What `Option` values were expected and which ones were created?
- 1. In the first case, a `Some(null)` value would make sense here, given that a `null` `NI` value was passed. A `None` value is created instead. This is because all was passed was `null` and it is not possible to distinguish between `NI?` and `NI` types in this case. Even though it is valid to manually create a `Some(null)` value.
- 2. `None` is expected and created
- 3. `None` is created, even though it may not be clear if a was meant to be null at the `NI` or `NI?` level.

At the `Result`/`Ok` level, having a non-nullable `T` (i.e. `T extends Object`) would bring only benefits. An `Option<T>` type should be defined instead of a nullable `T?`. No longer having to decide between `Option<T>` and nullable type `T?` will result in a much more uniform style.

It is fine for `E` to extend `Object`, because:
- An instance of `Null` cannot be thrown anyway.
  - An `Object` must be thrown, which important for `catchOption`, `catchOptionAsync`, `catchResult` and `catchResultAsync`.
- `Null` would not be a good candidate for `Err`'s type anyway.

In conclusion, enforcing non-nullable types removes ambiguity and prevents bugs.